### PR TITLE
Add preprocessing visualization notebook

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,21 @@
+data_dir: "data"
+output_dir: "output/experiments"
+
+# preprocessing hyperparameters
+preprocessing:
+  window_size: 128
+  stride: 64
+  sampling_rate: 50.0
+  fft_bands:
+    - [0.5, 2]
+    - [2, 5]
+    - [5, 10]
+    - [10, 20]
+  wavelet: "db4"
+  wavelet_level: 3
+  tda_dimension: 1
+  tda_bins: 20
+  tda_sigma: 0.1
+  tof_depth: 5
+  tof_height: 8
+  tof_width: 8

--- a/doc/preprocessing_pipeline.md
+++ b/doc/preprocessing_pipeline.md
@@ -1,0 +1,43 @@
+# 前処理パイプライン概要
+
+このプロジェクトではセンサーデータと Demographics 情報を統合する前処理モジュール `src/utils/preprocessing.py` を作成しました。
+
+## 主な処理内容
+
+1. **IMU ワールド座標変換**
+   - クォータニオンを回転行列に変換し、加速度ベクトルをワールド座標へ変換します。
+   - 重力成分を除外して線形加速度を算出する関数 `linear_acceleration` を実装しました。
+2. **スライディングウィンドウ生成**
+   - `create_sliding_windows_with_demographics` で時系列データを固定長ウィンドウに変換します。
+   - 各ウィンドウには静的な Demographics 特徴量を付与します。
+3. **正規化処理**
+   - センサーデータおよび Demographics データを `StandardScaler` で正規化するユーティリティを提供します。
+4. **ピーク数特徴量**
+   - 各ウィンドウから軸ごとのピーク数を抽出する簡易な特徴量計算を追加しました。
+5. **欠損センサ検知フラグ**
+   - センサ列がすべて欠損している場合に `missing_flag_*` を付与します。
+6. **基本統計量抽出**
+   - 各ウィンドウで mean, std, range, RMS, energy と合成加速度の
+     mean/std を計算する `compute_basic_statistics` を追加しました。
+7. **FFT バンドエネルギー**
+   - `compute_fft_band_energy` で 0.5〜20Hz のバンド別エネルギーを算出します。
+8. **利き手反転正規化**
+   - `handedness_normalization` により左利きデータの Y/Z 軸を反転させます。
+9. **Wavelet 周波数特徴**
+   - `compute_wavelet_features` により離散 Wavelet 変換の各バンドエネルギーを抽出します。
+10. **TDA 特徴量**
+    - `compute_persistence_image_features` で位相的特徴を画像化します（`giotto-tda` 使用）。
+11. **Auto‑Encoder 誤差**
+    - 事前学習済み AE モデルを渡して `compute_autoencoder_reconstruction_error` で再構成誤差を取得します。
+12. **ToF 3D Voxel 化**
+    - `tof_to_voxel_tensor` で ToF センサ 5 層 × 8×8 グリッドを時系列テンソルに整形します。
+
+これらの関数を学習・推論時に共通利用することで、前処理の再現性を高めています。
+
+## ハイパーパラメータ管理と可視化
+
+前処理に関するパラメータは `config.yaml` の `preprocessing` セクションでまとめて管理しています。ウィンドウサイズや FFT バンドなどを変更すると各スクリプトに自動反映されます。
+デフォルトでは `window_size=128`、`stride=64` を使用しています。
+
+実装した処理の挙動は `notebooks/preprocessing_visualization.ipynb` で確認できます。サンプルデータを用いて線形加速度計算や FFT バンドエネルギーの取得を行い、Matplotlib によるグラフ表示例を掲載しています。
+追加の可視化例として `notebooks/feature_block_demo.ipynb` では、基本統計やFFTエネルギーの計算結果をグラフ化しています。

--- a/notebooks/feature_block_demo.ipynb
+++ b/notebooks/feature_block_demo.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 前処理機能のデモ\n",
+    "\n",
+    "このノートでは、`src/utils/preprocessing.py` で実装した各機能を用いて合成データから特徴量を計算し、図で確認します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from src.utils import preprocessing\n",
+    "from src.utils.config_utils import get_preprocessing_params\n",
+    "\n",
+    "params = get_preprocessing_params()\n",
+    "window_size = params['window_size']\n",
+    "fs = params['sampling_rate']\n",
+    "\n",
+    "t = np.linspace(0, window_size/fs, window_size)\n",
+    "acc = np.stack([\n",
+    "    np.sin(2*np.pi*1*t),\n",
+    "    np.sin(2*np.pi*0.5*t),\n",
+    "    np.cos(2*np.pi*1.5*t)\n",
+    "], axis=1)\n",
+    "quat = np.tile([1,0,0,0], (window_size,1))\n",
+    "df = pd.DataFrame(acc, columns=['acc_x','acc_y','acc_z'])\n",
+    "for i,col in enumerate(['rot_w','rot_x','rot_y','rot_z']):\n",
+    "    df[col] = quat[:,i]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# world linear acceleration\n",
+    "df[['lin_acc_x','lin_acc_y','lin_acc_z']] = [\n",
+    "    preprocessing.linear_acceleration(row[['acc_x','acc_y','acc_z']].values,\n",
+    "                                      row[['rot_w','rot_x','rot_y','rot_z']].values)\n",
+    "    for _, row in df.iterrows()\n",
+    "]\n",
+    "\n",
+    "# compute statistics and peaks\n",
+    "window = df[['lin_acc_x','lin_acc_y','lin_acc_z']].values[np.newaxis,:,:]\n",
+    "stats = preprocessing.compute_basic_statistics(window)\n",
+    "peaks = preprocessing.compute_peak_features(window)\n",
+    "fft_energy = preprocessing.compute_fft_band_energy(window, fs=fs, bands=params['fft_bands'])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot linear acceleration\n",
+    "plt.figure(figsize=(6,3))\n",
+    "plt.plot(t, df['lin_acc_x'], label='lin_acc_x')\n",
+    "plt.xlabel('Time [s]')\n",
+    "plt.ylabel('Acceleration')\n",
+    "plt.title('Linear Acceleration Example')\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "\n",
+    "# plot statistics as bar chart\n",
+    "plt.figure(figsize=(6,3))\n",
+    "labels = [f'stat_{i}' for i in range(stats.shape[1])]\n",
+    "plt.bar(labels, stats[0])\n",
+    "plt.title('Basic Statistics')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.show()\n",
+    "\n",
+    "# plot FFT energy\n",
+    "plt.figure(figsize=(6,3))\n",
+    "for i, band in enumerate(params['fft_bands']):\n",
+    "    plt.bar(i, fft_energy[0, i], label=f'{band[0]}-{band[1]}Hz')\n",
+    "plt.title('FFT Band Energy')\n",
+    "plt.ylabel('Power')\n",
+    "plt.xticks(range(len(params['fft_bands'])), [f'{b[0]}-{b[1]}Hz' for b in params['fft_bands']])\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/preprocessing_visualization.ipynb
+++ b/notebooks/preprocessing_visualization.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 前処理可視化ノート\n",
+    "前処理モジュール `src/utils/preprocessing.py` で実装した各種処理の効果を確認するためのデモです。\n",
+    "ハイパーパラメータは `config.yaml` から読み込みます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from src.utils import preprocessing\n",
+    "from src.utils.config_utils import get_preprocessing_params\n",
+    "\n",
+    "params = get_preprocessing_params()\n",
+    "window_size = params.get('window_size', 128)\n",
+    "stride = params.get('stride', 64)\n",
+    "\n",
+    "t = np.linspace(0, window_size/params['sampling_rate'], window_size)\n",
+    "acc_x = np.sin(2*np.pi*1*t)\n",
+    "acc_y = np.cos(2*np.pi*1*t)\n",
+    "acc_z = np.sin(2*np.pi*0.5*t)\n",
+    "quat = np.array([np.ones_like(t), np.zeros_like(t), np.zeros_like(t), np.zeros_like(t)]).T\n",
+    "df = pd.DataFrame({\n",
+    "    'acc_x': acc_x,\n",
+    "    'acc_y': acc_y,\n",
+    "    'acc_z': acc_z,\n",
+    "    'rot_w': quat[:,0],\n",
+    "    'rot_x': quat[:,1],\n",
+    "    'rot_y': quat[:,2],\n",
+    "    'rot_z': quat[:,3],\n",
+    "    'handedness': 1,\n",
+    "    'gesture': 0,\n",
+    "    'subject': 0,\n",
+    "    'sequence_id': 0,\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# 線形加速度の計算例\n",
+    "lin_acc = np.array([\n",
+    "    preprocessing.linear_acceleration(row[['acc_x','acc_y','acc_z']].values,\n",
+    "                                      row[['rot_w','rot_x','rot_y','rot_z']].values)\n",
+    "    for _, row in df.iterrows()\n",
+    "])\n",
+    "df[['lin_acc_x','lin_acc_y','lin_acc_z']] = lin_acc\n",
+    "\n",
+    "# FFT バンドエネルギー\n",
+    "bands = params['fft_bands']\n",
+    "window = df[['lin_acc_x','lin_acc_y','lin_acc_z']].values[np.newaxis, :, :]\n",
+    "fft_energy = preprocessing.compute_fft_band_energy(window, fs=params['sampling_rate'], bands=bands)\n",
+    "fft_energy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6,3))\n",
+    "plt.plot(t, df['acc_x'], label='acc_x')\n",
+    "plt.plot(t, df['lin_acc_x'], label='lin_acc_x')\n",
+    "plt.legend()\n",
+    "plt.title('Linear Acceleration Example')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "nbconvert_exporter": "python",
+   "mimetype": "text/x-python",
+   "file_extension": ".py"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/data/data_loader_fix.py
+++ b/src/data/data_loader_fix.py
@@ -6,6 +6,7 @@ import pickle
 import numpy as np
 import pandas as pd
 from pathlib import Path
+from src.utils.config_utils import load_config
 
 def load_w64_s16_data():
     """
@@ -14,12 +15,8 @@ def load_w64_s16_data():
     Returns:
         tuple: (sensor_data, demographics_data, labels)
     """
-    # 絶対パスに修正
-    project_root = Path(__file__).parent.parent.parent
-    data_dir = project_root / "output/experiments/lstm_v2_w64_s16/preprocessed"
-
-    # 正しいパスに修正
-    data_dir = Path("/mnt/c/Users/ShunK/works/CMI_comp/output/experiments/lstm_v2_w64_s16/preprocessed")
+    config = load_config()
+    data_dir = Path(config["output_dir"]) / "lstm_v2_w64_s16" / "preprocessed"
     
     print(f"📁 データ読み込み中...")
     
@@ -74,7 +71,8 @@ def load_w128_s32_data():
     Returns:
         tuple: (X_sensor, X_demographics, y, meta_info)
     """
-    preprocessed_path = Path("../output/experiments/lstm_v2_w128_s32/preprocessed/")
+    config = load_config()
+    preprocessed_path = Path(config["output_dir"]) / "lstm_v2_w128_s32" / "preprocessed"
     
     print(f"📁 前処理済みデータパス: {preprocessed_path}")
     

--- a/src/trainers/lstm_v2_trainer.py
+++ b/src/trainers/lstm_v2_trainer.py
@@ -19,6 +19,7 @@ from sklearn.metrics import f1_score, classification_report
 import matplotlib.pyplot as plt
 import seaborn as sns
 import warnings
+from src.utils.config_utils import load_config
 warnings.filterwarnings('ignore')
 
 # TensorFlow GPU設定
@@ -50,12 +51,14 @@ class LSTMv2Trainer:
         """
         self.experiment_name = experiment_name
         self.window_config = window_config
-        self.output_dir = Path(f"../output/experiments/{experiment_name}_{window_config}")
+        config = load_config()
+        base_output = Path(config["output_dir"])
+        self.output_dir = base_output / f"{experiment_name}_{window_config}"
         self.models_dir = self.output_dir / "models"
         self.results_dir = self.output_dir / "results"
-        
+
         # 前処理済みデータのパス
-        self.preprocessed_dir = Path(f"/mnt/c/Users/ShunK/works/CMI_comp/output/experiments/lstm_v2_{window_config}/preprocessed")
+        self.preprocessed_dir = base_output / f"lstm_v2_{window_config}" / "preprocessed"
         
         # ディレクトリ作成
         self.output_dir.mkdir(parents=True, exist_ok=True)

--- a/src/utils/config_utils.py
+++ b/src/utils/config_utils.py
@@ -1,0 +1,15 @@
+import yaml
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "config.yaml"
+
+
+def load_config():
+    with open(CONFIG_PATH, "r") as f:
+        return yaml.safe_load(f)
+
+
+def get_preprocessing_params():
+    """Return preprocessing-related hyperparameters from config."""
+    cfg = load_config()
+    return cfg.get("preprocessing", {})

--- a/src/utils/preprocessing.py
+++ b/src/utils/preprocessing.py
@@ -1,0 +1,345 @@
+# -*- coding: utf-8 -*-
+"""Preprocessing utilities for the CMI competition.
+
+This module provides functions for:
+- IMU world coordinate transformation
+- sliding window generation with demographics
+- normalization utilities
+- simple peak feature extraction
+"""
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+from scipy.signal import find_peaks
+
+
+def quaternion_to_rotation_matrix(q: np.ndarray) -> np.ndarray:
+    """Convert quaternion q=[w, x, y, z] to a rotation matrix."""
+    w, x, y, z = q
+    return np.array([
+        [1 - 2 * (y ** 2 + z ** 2), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+        [2 * (x * y + z * w), 1 - 2 * (x ** 2 + z ** 2), 2 * (y * z - x * w)],
+        [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x ** 2 + y ** 2)],
+    ])
+
+
+def rotate_acceleration(acc: np.ndarray, quat: np.ndarray) -> np.ndarray:
+    """Rotate accelerometer vector to world coordinates."""
+    return quaternion_to_rotation_matrix(quat) @ acc
+
+
+def linear_acceleration(acc: np.ndarray, quat: np.ndarray, gravity: float = 9.81) -> np.ndarray:
+    """Return linear acceleration by removing gravity after rotation."""
+    acc_world = rotate_acceleration(acc, quat)
+    gravity_vec = np.array([0, 0, gravity])
+    return acc_world - gravity_vec
+
+
+def create_sliding_windows_with_demographics(
+    df: pd.DataFrame,
+    window_size: int,
+    stride: int,
+    sensor_cols: list,
+    demographics_cols: list,
+    min_sequence_length: int = 10,
+    padding_value: float = 0.0,
+):
+    """Create sliding windows for sequences with static demographics features."""
+    X_sensor_windows = []
+    X_demographics_windows = []
+    y_windows = []
+    sequence_info = []
+
+    grouped = df.groupby(["subject", "sequence_id"])
+    for (subject, sequence_id), group in grouped:
+        sequence_length = len(group)
+        gesture = group["gesture"].iloc[0]
+        if sequence_length < min_sequence_length:
+            continue
+        sensor_data = group[sensor_cols].values
+        demographics_data = group[demographics_cols].iloc[0].values
+        need_padding = sequence_length < window_size
+        if need_padding:
+            padding_size = window_size - sequence_length
+            padding = np.full((padding_size, len(sensor_cols)), padding_value)
+            sensor_data = np.vstack([sensor_data, padding])
+        for start_idx in range(0, len(sensor_data) - window_size + 1, stride):
+            end_idx = start_idx + window_size
+            window = sensor_data[start_idx:end_idx]
+            X_sensor_windows.append(window)
+            X_demographics_windows.append(demographics_data)
+            y_windows.append(gesture)
+            sequence_info.append(
+                {
+                    "subject": subject,
+                    "sequence_id": sequence_id,
+                    "start_idx": start_idx,
+                    "end_idx": end_idx,
+                    "original_length": sequence_length,
+                    "padded": need_padding,
+                }
+            )
+
+    X_sensor_windows = np.array(X_sensor_windows, dtype=np.float32)
+    X_demographics_windows = np.array(X_demographics_windows, dtype=np.float32)
+    y_windows = np.array(y_windows)
+
+    return X_sensor_windows, X_demographics_windows, y_windows, sequence_info
+
+
+def normalize_sensor_data(X: np.ndarray):
+    """Normalize sensor windows and return normalized data and scaler."""
+    scaler = StandardScaler()
+    n_samples, n_timesteps, n_features = X.shape
+    flat = X.reshape(-1, n_features)
+    flat = np.nan_to_num(flat, nan=0.0)
+    normalized = scaler.fit_transform(flat).reshape(n_samples, n_timesteps, n_features)
+    return normalized, scaler
+
+
+def normalize_tabular_data(X: np.ndarray):
+    """Normalize tabular demographics data."""
+    scaler = StandardScaler()
+    normalized = scaler.fit_transform(X)
+    return normalized, scaler
+
+
+def extract_peak_features(window: np.ndarray) -> np.ndarray:
+    """Return peak counts for each axis within a window."""
+    features = []
+    for i in range(window.shape[1]):
+        peaks, _ = find_peaks(window[:, i])
+        features.append(len(peaks))
+    return np.array(features, dtype=np.float32)
+
+
+def compute_peak_features(X_windows: np.ndarray) -> np.ndarray:
+    """Compute peak count features for multiple windows."""
+    return np.vstack([extract_peak_features(w) for w in X_windows])
+
+
+def add_missing_sensor_flags(df: pd.DataFrame, sensor_groups: dict) -> pd.DataFrame:
+    """Add missing sensor flag columns for each sensor group.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe containing raw sensor columns.
+    sensor_groups : dict
+        Dictionary mapping flag column names to a list of column names that
+        belong to the sensor group.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with additional boolean flag columns.
+    """
+    for flag, cols in sensor_groups.items():
+        df[flag] = df[cols].isna().all(axis=1)
+    return df
+
+
+def compute_basic_statistics(X_windows: np.ndarray) -> np.ndarray:
+    """Compute simple statistics for each window.
+
+    Statistics include mean, std, range, RMS, energy for each feature and
+    mean/std of 3D vector magnitude for the first three axes (acceleration).
+    """
+    means = X_windows.mean(axis=1)
+    stds = X_windows.std(axis=1)
+    ranges = X_windows.max(axis=1) - X_windows.min(axis=1)
+    rms = np.sqrt((X_windows ** 2).mean(axis=1))
+    energy = (X_windows ** 2).sum(axis=1)
+
+    # magnitude assuming the first three columns represent a vector
+    if X_windows.shape[2] >= 3:
+        mag = np.linalg.norm(X_windows[:, :, :3], axis=2)
+        mag_mean = mag.mean(axis=1, keepdims=True)
+        mag_std = mag.std(axis=1, keepdims=True)
+        stats = np.hstack([means, stds, ranges, rms, energy, mag_mean, mag_std])
+    else:
+        stats = np.hstack([means, stds, ranges, rms, energy])
+    return stats
+
+
+def compute_fft_band_energy(
+    X_windows: np.ndarray,
+    fs: float = 50.0,
+    bands: list | None = None,
+) -> np.ndarray:
+    """Compute FFT band energies for each window and feature.
+
+    Parameters
+    ----------
+    X_windows : np.ndarray
+        Shape (n_windows, window_size, n_features).
+    fs : float, optional
+        Sampling frequency used to compute the FFT. Defaults to 50Hz.
+    bands : list of tuple, optional
+        List of (low, high) frequency pairs specifying the bands.
+        Defaults to [(0.5, 2), (2, 5), (5, 10), (10, 20)].
+
+    Returns
+    -------
+    np.ndarray
+        Concatenated band energies for all features.
+    """
+    if bands is None:
+        bands = [(0.5, 2), (2, 5), (5, 10), (10, 20)]
+
+    n_windows, window_size, n_features = X_windows.shape
+    freqs = np.fft.rfftfreq(window_size, d=1.0 / fs)
+    fft_vals = np.fft.rfft(X_windows, axis=1)
+    power = np.abs(fft_vals) ** 2
+
+    band_energy_list = []
+    for low, high in bands:
+        mask = (freqs >= low) & (freqs < high)
+        band_energy = power[:, mask, :].sum(axis=1)
+        band_energy_list.append(band_energy)
+
+    return np.concatenate(band_energy_list, axis=1)
+
+
+def handedness_normalization(
+    df: pd.DataFrame,
+    axis_cols: list,
+    handedness_col: str = "handedness",
+) -> pd.DataFrame:
+    """Flip Y/Z axes for left handed subjects.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe containing IMU axes.
+    axis_cols : list
+        Columns corresponding to [x, y, z] axes.
+    handedness_col : str, optional
+        Column indicating handedness (0 left, 1 right).
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with axes flipped for left handed samples.
+    """
+    y_col, z_col = axis_cols[1], axis_cols[2]
+    left_mask = df[handedness_col] == 0
+    df.loc[left_mask, [y_col, z_col]] *= -1
+    return df
+
+
+def compute_wavelet_features(
+    X_windows: np.ndarray,
+    wavelet: str = "db4",
+    level: int = 3,
+) -> np.ndarray:
+    """Extract wavelet band energies using discrete wavelet transform."""
+    import pywt  # local import to avoid hard dependency
+
+    features = []
+    for window in X_windows:
+        axis_feats = []
+        for i in range(window.shape[1]):
+            coeffs = pywt.wavedec(window[:, i], wavelet=wavelet, level=level)
+            energies = [np.sum(c ** 2) for c in coeffs]
+            axis_feats.extend(energies)
+        features.append(axis_feats)
+    return np.array(features, dtype=np.float32)
+
+
+def compute_persistence_image_features(
+    X_windows: np.ndarray,
+    dimension: int = 1,
+    n_bins: int = 20,
+    sigma: float = 0.1,
+) -> np.ndarray:
+    """Compute persistence image features using giotto-tda.
+
+    This function requires `giotto-tda` to be installed. If the package is not
+    available, an ImportError is raised when calling this function.
+    """
+    try:
+        from gtda.time_series import TakensEmbedding
+        from gtda.homology import VietorisRipsPersistence
+        from gtda.diagrams import PersistenceImage
+    except Exception as e:  # pragma: no cover - library may not be installed
+        raise ImportError(
+            "giotto-tda is required for persistence image features"
+        ) from e
+
+    embedding = TakensEmbedding(time_delay=1, dimension=dimension)
+    persistence = VietorisRipsPersistence(homology_dimensions=[0, 1])
+    pimage = PersistenceImage(bandwidth=sigma, n_bins=(n_bins, n_bins))
+
+    features = []
+    for window in X_windows:
+        emb = embedding.fit_transform(window)
+        diag = persistence.fit_transform(emb[np.newaxis, ...])
+        img = pimage.fit_transform(diag)
+        features.append(img.reshape(-1))
+    return np.array(features, dtype=np.float32)
+
+
+def compute_autoencoder_reconstruction_error(
+    X_windows: np.ndarray,
+    model,
+) -> np.ndarray:
+    """Compute per-window MSE reconstruction error using a trained AE model."""
+    reconstructed = model.predict(X_windows, verbose=0)
+    mse = ((X_windows - reconstructed) ** 2).mean(axis=(1, 2))
+    return mse.reshape(-1, 1)
+
+
+def tof_to_voxel_tensor(
+    df: pd.DataFrame,
+    fill_value: float = 0.0,
+    prefix: str = "tof_",
+) -> np.ndarray:
+    """Convert ToF sensor columns to a 3D voxel tensor.
+
+    The dataframe is expected to contain columns in the form
+    ``tof_{sensor}_v{index}`` where ``index`` ranges from 0 to
+    ``height * width - 1``. Sensor numbers are used as the depth
+    dimension of the resulting tensor.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe with ToF columns.
+    fill_value : float, optional
+        Value used to replace NaN or -1 readings. Defaults to 0.0.
+    prefix : str, optional
+        Prefix for ToF column names. Defaults to "tof_".
+
+    Returns
+    -------
+    np.ndarray
+        Tensor with shape ``(len(df), depth, height, width)``.
+    """
+    import re
+
+    pattern = re.compile(fr"^{prefix}(\d+)_v(\d+)$")
+    matches = [(col, pattern.match(col)) for col in df.columns]
+    sensor_nums = sorted({int(m.group(1)) for col, m in matches if m})
+    if not sensor_nums:
+        raise ValueError("No ToF columns found in dataframe")
+
+    # Determine grid size from the largest voxel index
+    voxel_indices = [int(m.group(2)) for col, m in matches if m]
+    max_index = max(voxel_indices)
+    width = height = int(np.sqrt(max_index + 1))
+    depth = len(sensor_nums)
+
+    n_timesteps = len(df)
+    tensor = np.full((n_timesteps, depth, height, width), fill_value, dtype=np.float32)
+
+    for d, sensor_num in enumerate(sensor_nums):
+        for idx in range(height * width):
+            col = f"{prefix}{sensor_num}_v{idx}"
+            if col in df.columns:
+                values = df[col].replace(-1, fill_value).to_numpy(dtype=np.float32)
+                r, c = divmod(idx, width)
+                tensor[:, d, r, c] = values
+
+    return tensor


### PR DESCRIPTION
## Summary
- manage preprocessing hyperparameters in `config.yaml`
- expose `get_preprocessing_params` helper for easy access
- document parameter usage and visualization notebook
- provide `preprocessing_visualization.ipynb` to demonstrate feature steps
- add ToF sensor voxel tensor conversion utility
- update sliding window defaults to 128/64
- add feature block demo notebook

## Testing
- `python -m py_compile src/utils/preprocessing.py src/utils/config_utils.py src/data/data_loader_fix.py src/trainers/lstm_v2_trainer.py`


------
https://chatgpt.com/codex/tasks/task_e_686e263d20f88328bc3ca58fe7d40826