### PR TITLE
Enable configurable cache directory

### DIFF
--- a/src/utils/config_utils.py
+++ b/src/utils/config_utils.py
@@ -13,3 +13,9 @@ def get_preprocessing_params():
     """Return preprocessing-related hyperparameters from config."""
     cfg = load_config()
     return cfg.get("preprocessing", {})
+
+
+def get_cache_dir(cfg: dict | None = None) -> Path:
+    """Return cache directory Path from config."""
+    cfg = cfg or load_config()
+    return Path(cfg.get("cache_dir", "cache"))

--- a/src/utils/pipeline.py
+++ b/src/utils/pipeline.py
@@ -10,9 +10,8 @@ import pickle
 import hashlib
 from sklearn.preprocessing import StandardScaler
 
-from .io_utils import CACHE_DIR, df_md5
-
-from .config_utils import load_config
+from .io_utils import df_md5
+from .config_utils import load_config, get_cache_dir
 from .preprocessing import create_sliding_windows_with_demographics
 from .tof import tof_to_voxel_tensor
 from .feature_engineering import (
@@ -38,9 +37,10 @@ class WindowTensorBuilder:
             + self.config.get("sensor_thm_cols", [])
         )
         self.demographics_cols = self.config.get("demographics_cols", [])
-        self.cache_file = CACHE_DIR / "windows.pkl"
-        self.meta_file = CACHE_DIR / "windows_meta.json"
-        CACHE_DIR.mkdir(exist_ok=True)
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "windows.pkl"
+        self.meta_file = self.cache_dir / "windows_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
 
     def build(self, df: pd.DataFrame, use_cache: bool = True):
         md5 = df_md5(df)
@@ -75,9 +75,10 @@ class TabularFeatureBuilder:
         self.sampling_rate = pp.get("sampling_rate", 50.0)
         self.fft_bands = pp.get("fft_bands", [])
         self.window_builder = WindowTensorBuilder(self.config)
-        self.cache_file = CACHE_DIR / "tabular_features.pkl"
-        self.meta_file = CACHE_DIR / "tabular_meta.json"
-        CACHE_DIR.mkdir(exist_ok=True)
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tabular_features.pkl"
+        self.meta_file = self.cache_dir / "tabular_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
 
     def build(self, df: pd.DataFrame, use_cache: bool = True):
         md5 = df_md5(df)
@@ -117,9 +118,10 @@ class ToFVoxelBuilder:
         h = pp.get("tof_height", 8)
         w = pp.get("tof_width", 8)
         self.tof_cols = [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)]
-        self.cache_file = CACHE_DIR / "tof_voxel.pkl"
-        self.meta_file = CACHE_DIR / "tof_meta.json"
-        CACHE_DIR.mkdir(exist_ok=True)
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tof_voxel.pkl"
+        self.meta_file = self.cache_dir / "tof_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
 
     def build(self, df: pd.DataFrame, use_cache: bool = True):
         md5 = df_md5(df)


### PR DESCRIPTION
## Summary
- add `get_cache_dir` helper
- use cache directory from config in preprocessing pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687318d166d48328b11dff7bf8c9dc30