### PR TITLE
Add save/load to Preprocessor

### DIFF
--- a/doc/preprocessing_flow_jp.md
+++ b/doc/preprocessing_flow_jp.md
@@ -74,3 +74,8 @@
 
 ウィンドウ化前後の正規化や利き手補正の順序は、`doc/preprocessing_pipeline.md` の「主な処理の流れ」に準拠しています【F:doc/preprocessing_pipeline.md†L21-L37】。
 
+### 前処理結果の保存と再利用
+
+`Preprocessor` オブジェクトは `save(path)` メソッドでスケーラー設定とともに保存できます。
+推論時には `Preprocessor.load(path)` で復元し、同じ前処理を適用します。
+

--- a/doc/preprocessing_outputs.md
+++ b/doc/preprocessing_outputs.md
@@ -13,7 +13,7 @@
 | `train_tof_voxel.pkl` / `test_tof_voxel.pkl` | ToF ピクセルを (T, depth, H, W) へ整形したテンソル | `(time, depth, H, W)` | ToF 3D CNN 用 |
 | `train_labels.pkl` / `test_labels.pkl` | 各ウィンドウのラベル ID | `(n_windows,)` | 教師データ |
 | `train_info.pkl` / `test_info.pkl` | `sequence_id` や `start_idx` などのメタ情報 | - | 後続処理用 |
-| `preprocessor.pkl` | 学習済み `Preprocessor` オブジェクト | - | 推論時の再利用 |
+| `preprocessor.pkl` | 学習済み `Preprocessor` を `Preprocessor.save()` で保存したファイル | - | `Preprocessor.load()` で読み込み |
 
 ※ `--mode predict` で実行した場合は `predict_*.pkl` が生成されます。
 

--- a/scripts/run_preprocessing.py
+++ b/scripts/run_preprocessing.py
@@ -14,9 +14,9 @@ specified in the config file and saves processed data under
 from __future__ import annotations
 
 import argparse
-import pickle
 from pathlib import Path
 from typing import Any
+import pickle
 
 import pandas as pd
 import yaml
@@ -76,13 +76,11 @@ def main() -> None:
         # save results
         save_dict(train_data, "train", pre_dir)
         save_dict(test_data, "test", pre_dir)
-        with open(pre_dir / "preprocessor.pkl", "wb") as f:
-            pickle.dump(pp, f)
+        pp.save(pre_dir / "preprocessor.pkl")
 
     else:  # predict
         df = pd.read_csv(data_dir / "test.csv")
-        with open(pre_dir / "preprocessor.pkl", "rb") as f:
-            pp = pickle.load(f)
+        pp = Preprocessor.load(pre_dir / "preprocessor.pkl")
         data = pp.transform(df, use_cache=args.use_cache)
         save_dict(data, "predict", pre_dir)
 

--- a/src/utils/pipeline.py
+++ b/src/utils/pipeline.py
@@ -261,3 +261,37 @@ class Preprocessor:
     def fit_transform(self, df: pd.DataFrame, use_cache: bool = True) -> dict:
         self.fit(df, use_cache=use_cache)
         return self.transform(df, use_cache=use_cache)
+
+    def save(self, path: Path) -> None:
+        """Save scaler objects and settings to a pickle file."""
+        data = {
+            "config": self.config,
+            "use_handedness": self.use_handedness,
+            "use_basic_cleaning": self.use_basic_cleaning,
+            "use_interp_cleaning": self.use_interp_cleaning,
+            "use_world_acc": self.use_world_acc,
+            "sensor_scaler": self.sensor_scaler,
+            "demo_scaler": self.demo_scaler,
+            "tab_scaler": self.tab_scaler,
+            "_fitted": self._fitted,
+        }
+        with open(path, "wb") as f:
+            pickle.dump(data, f)
+
+    @classmethod
+    def load(cls, path: Path) -> "Preprocessor":
+        """Load scalers and settings from a pickle file."""
+        with open(path, "rb") as f:
+            data = pickle.load(f)
+        obj = cls(
+            data.get("config"),
+            use_handedness=data.get("use_handedness", True),
+            use_basic_cleaning=data.get("use_basic_cleaning", True),
+            use_interp_cleaning=data.get("use_interp_cleaning", True),
+            use_world_acc=data.get("use_world_acc"),
+        )
+        obj.sensor_scaler = data["sensor_scaler"]
+        obj.demo_scaler = data["demo_scaler"]
+        obj.tab_scaler = data["tab_scaler"]
+        obj._fitted = data.get("_fitted", False)
+        return obj


### PR DESCRIPTION
## Summary
- implement `Preprocessor.save` and `Preprocessor.load`
- use the new API in `run_preprocessing.py`
- document the new workflow in preprocessing docs

## Testing
- `python -m py_compile src/utils/pipeline.py scripts/run_preprocessing.py`
- ⚠️ `pip install pandas scikit-learn --quiet` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68732dcd37788328bb134dd8e7176bb7