### PR TITLE
Add preprocessing outputs doc

### DIFF
--- a/doc/preprocessing_flow_jp.md
+++ b/doc/preprocessing_flow_jp.md
@@ -2,6 +2,8 @@
 
 本プロジェクトで用いる前処理ステップを日本語で整理します。センサ時系列データと年齢・性別などの **Demographics** 情報をどの順番で処理し、各モデルに入力するかをまとめました。
 
+生成される前処理出力ファイルの一覧は [preprocessing_outputs.md](preprocessing_outputs.md) にまとめています。
+
 ## 1. 生データのロード
 
 - `train.csv` / `test.csv` … センサ時系列 (加速度, 回転, Thermal, ToF など)

--- a/doc/preprocessing_outputs.md
+++ b/doc/preprocessing_outputs.md
@@ -1,16 +1,15 @@
 # 前処理スクリプト出力一覧
 
-`scripts/run_preprocessing.py` を実行すると、`output/experiments/<experiment_name>/preprocessed/`
-以下に複数の pickle ファイルが保存されます。各ファイルの内容と主な用途を整理します。
+`scripts/run_preprocessing.py` を実行すると、`output/experiments/<experiment_name>/preprocessed/` 以下に複数の pickle ファイルが保存されます。各ファイルの内容と主な用途を整理します。
 
 ## 出力ファイル一覧
 
 | ファイル名 | 内容 | 典型的な形状 | 主な用途 |
 |------------|------|-------------|---------|
-| `train_windows.pkl` / `test_windows.pkl` | ウィンドウ化された IMU センサテンソル | `(n_windows, window_size, n_features)` | GRU/CNN 系モデルの入力 |
-| `train_demographics.pkl` / `test_demographics.pkl` | ウィンドウ単位の Demographics 特徴量 | `(n_windows, n_demo)` | 時系列モデルとの結合用 |
-| `train_tabular.pkl` / `test_tabular.pkl` | Block A–H,M を統合した Tabular 特徴量 | `(n_windows, n_features)` | LightGBM/CatBoost 用 |
-| `train_tof_voxel.pkl` / `test_tof_voxel.pkl` | ToF ピクセルを (T, depth, H, W) へ整形したテンソル | `(time, depth, H, W)` | ToF 3D CNN 用 |
+| `train_windows.pkl` / `test_windows.pkl` | ウィンドウ化された IMU センサテンソル | `(n_windows, 128, 12)` | GRU/CNN 系モデルの入力 |
+| `train_demographics.pkl` / `test_demographics.pkl` | ウィンドウ単位の Demographics 特徴量 | `(n_windows, 7)` | 時系列モデルとの結合用 |
+| `train_tabular.pkl` / `test_tabular.pkl` | Block A–H,M を統合した Tabular 特徴量 | `(n_windows, 120)` | LightGBM/CatBoost 用 |
+| `train_tof_voxel.pkl` / `test_tof_voxel.pkl` | ToF ピクセルを (T, depth, H, W) へ整形したテンソル | `(time, 5, 8, 8)` | ToF 3D CNN 用 |
 | `train_labels.pkl` / `test_labels.pkl` | 各ウィンドウのラベル ID | `(n_windows,)` | 教師データ |
 | `train_info.pkl` / `test_info.pkl` | `sequence_id` や `start_idx` などのメタ情報 | - | 後続処理用 |
 | `preprocessor.pkl` | 学習済み `Preprocessor` オブジェクト | - | 推論時の再利用 |
@@ -32,5 +31,4 @@ graph TD
     E3 --> F3[ToF 3D CNN]
 ```
 
-上図の A〜D が共通処理で、E 以降がモデル固有部に相当します。詳細な実装は
-[前処理パイプライン概要](preprocessing_pipeline.md) を参照してください。
+上図の A〜D が共通処理で、E 以降がモデル固有部に相当します。詳細な実装は [前処理パイプライン概要](preprocessing_pipeline.md) を参照してください。


### PR DESCRIPTION
## Summary
- document preprocessing outputs and their shapes
- add link from preprocessing flow doc to this new documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732ddc4ba08328b35b5034b7192808