### PR TITLE
Implement ToF window creation and caching

### DIFF
--- a/src/utils/pipeline.py
+++ b/src/utils/pipeline.py
@@ -17,6 +17,7 @@ import yaml
 
 from .preprocessing import (
     create_sliding_windows_with_demographics,
+    create_tof_windows_with_info,
     handedness_correction_v2,
     clean_sensor_missing_values,
     clean_missing_sensor_data_parallel_disk,
@@ -226,6 +227,56 @@ class ToFVoxelBuilder:
         return result
 
 
+class ToFWindowBuilder:
+    """Create sliding windows from ToF voxel tensor."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        self.window_size = pp.get("window_size", 128)
+        self.stride = pp.get("stride", 64)
+        self.min_len = pp.get("min_sequence_length", 10)
+        self.fill_value = pp.get("padding_value", 0.0)
+        depth = pp.get("tof_depth", 5)
+        h = pp.get("tof_height", 8)
+        w = pp.get("tof_width", 8)
+        self.tof_cols = [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)]
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tof_windows.pkl"
+        self.meta_file = self.cache_dir / "tof_windows_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(self, df: pd.DataFrame, use_cache: bool = True):
+        logger.info(
+            "Building ToF windows (size=%d, stride=%d, min_len=%d)",
+            self.window_size,
+            self.stride,
+            self.min_len,
+        )
+        md5 = df_md5(df)
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached ToF windows from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        result = create_tof_windows_with_info(
+            df,
+            window_size=self.window_size,
+            stride=self.stride,
+            tof_cols=self.tof_cols,
+            min_sequence_length=self.min_len,
+            fill_value=self.fill_value,
+        )
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info("ToF windows shape %s", result[0].shape)
+        return result
+
+
 class Preprocessor:
     """Manage preprocessing statistics and transformations."""
 
@@ -245,6 +296,7 @@ class Preprocessor:
         self.win_builder = WindowTensorBuilder(self.config)
         self.tab_builder = TabularFeatureBuilder(self.config)
         self.tof_builder = ToFVoxelBuilder(self.config)
+        self.tof_win_builder = ToFWindowBuilder(self.config)
 
         self.sensor_scaler = StandardScaler()
         self.demo_scaler = StandardScaler()
@@ -404,18 +456,21 @@ class Preprocessor:
         tab_normalized = self.tab_scaler.transform(tab_clean)
         
         tof_tensor = self.tof_builder.build(df_proc, use_cache=use_cache)
+        tof_windows, _ = self.tof_win_builder.build(df_proc, use_cache=use_cache)
         logger.info(
-            "Output shapes: windows=%s, demographics=%s, tabular=%s, tof=%s",
+            "Output shapes: windows=%s, demographics=%s, tabular=%s, tof=%s, tof_win=%s",
             X_sensor.shape,
             X_demo.shape,
             tab.shape,
             tof_tensor.shape,
+            tof_windows.shape,
         )
         return {
             "windows": X_sensor_normalized,
             "demographics": X_demo_normalized,
             "tabular": tab_normalized,
             "tof_voxel": tof_tensor,
+            "tof_windows": tof_windows,
             "labels": y,
             "info": info,
         }

--- a/src/utils/preprocessing.py
+++ b/src/utils/preprocessing.py
@@ -5,6 +5,7 @@ Preprocessing utilities for the CMI competition (commented version).
 
 import numpy as np
 import pandas as pd
+from .tof import tof_to_voxel_tensor
 
 
 # ============================================================
@@ -343,6 +344,71 @@ def create_sliding_windows_with_demographics(
         np.asarray(y_windows),
         info,
     )
+
+
+def create_tof_windows_with_info(
+    df: pd.DataFrame,
+    window_size: int,
+    stride: int,
+    tof_cols: list,
+    min_sequence_length: int = 10,
+    fill_value: float = 0.0,
+) -> tuple[np.ndarray, list[dict]]:
+    """Generate sliding windows for ToF voxel tensor with metadata.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe containing ToF pixel columns.
+    window_size : int
+        Length of each window.
+    stride : int
+        Step size between windows.
+    tof_cols : list
+        Column names of ToF pixels to be used.
+    min_sequence_length : int, default 10
+        Minimum sequence length to consider a sequence.
+    fill_value : float, default 0.0
+        Padding value for sequences shorter than ``window_size``.
+
+    Returns
+    -------
+    tuple[np.ndarray, list[dict]]
+        ``windows`` with shape ``(N, window_size, depth, H, W)`` and
+        ``info`` containing metadata for each window.
+    """
+
+    X_windows, info = [], []
+
+    for (subject, seq_id), g in df.groupby(["subject", "sequence_id"]):
+        seq_len = len(g)
+        if seq_len < min_sequence_length:
+            continue
+
+        tensor = tof_to_voxel_tensor(g[tof_cols], fill_value=fill_value)
+        need_pad = seq_len < window_size
+        if need_pad:
+            pad = np.full(
+                (window_size - seq_len,) + tensor.shape[1:],
+                fill_value,
+                dtype=tensor.dtype,
+            )
+            tensor = np.concatenate([tensor, pad], axis=0)
+
+        for s in range(0, len(tensor) - window_size + 1, stride):
+            e = s + window_size
+            X_windows.append(tensor[s:e])
+            info.append(
+                {
+                    "subject": subject,
+                    "sequence_id": seq_id,
+                    "start_idx": s,
+                    "end_idx": e,
+                    "padded": need_pad,
+                }
+            )
+
+    return np.asarray(X_windows, dtype=np.float32), info
 
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -13,6 +13,7 @@ from src.utils.pipeline import (
     WindowTensorBuilder,
     TabularFeatureBuilder,
     ToFVoxelBuilder,
+    ToFWindowBuilder,
     Preprocessor,
 )
 
@@ -148,6 +149,28 @@ def test_tof_voxel_builder(tmp_path: Path):
 
     assert builder.cache_file.exists()
     assert builder.meta_file.exists()
+
+
+def test_tof_window_builder(tmp_path: Path):
+    cfg = make_config(tmp_path)
+    df = make_dummy_df()
+    builder = ToFWindowBuilder(cfg)
+
+    windows, info = builder.build(df)
+
+    depth = cfg["preprocessing"]["tof_depth"]
+    h = cfg["preprocessing"]["tof_height"]
+    w = cfg["preprocessing"]["tof_width"]
+    assert windows.shape == (1, cfg["preprocessing"]["window_size"], depth, h, w)
+    assert len(info) == 1
+
+    assert builder.cache_file.exists()
+    assert builder.meta_file.exists()
+    md5_first = json.loads(builder.meta_file.read_text())["md5"]
+    win_cached, info_cached = builder.build(df)
+    md5_second = json.loads(builder.meta_file.read_text())["md5"]
+    assert md5_first == md5_second
+    np.testing.assert_allclose(windows, win_cached)
 
 
 def test_preprocessor_save_load(tmp_path: Path):

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -94,6 +94,7 @@ def test_preprocessor_cache_and_transform(tmp_path: Path):
     assert result["demographics"].shape == (1, 7)
     assert result["tabular"].shape == (1, 129)
     assert result["tof_voxel"].shape == (len(df), 5, 8, 8)
+    assert result["tof_windows"].shape == (1, 16, 5, 8, 8)
     assert result["labels"].shape == (1,)
     assert len(result["info"]) == 1
 
@@ -101,6 +102,7 @@ def test_preprocessor_cache_and_transform(tmp_path: Path):
         (pp.win_builder.cache_file, pp.win_builder.meta_file),
         (pp.tab_builder.cache_file, pp.tab_builder.meta_file),
         (pp.tof_builder.cache_file, pp.tof_builder.meta_file),
+        (pp.tof_win_builder.cache_file, pp.tof_win_builder.meta_file),
     ]
     cleaned = pp._maybe_clean(df)
     md5 = df_md5(cleaned)
@@ -114,5 +116,5 @@ def test_preprocessor_cache_and_transform(tmp_path: Path):
     pp.save(pkl)
     loaded = Preprocessor.load(pkl)
     out = loaded.transform(df)
-    for key in ["windows", "demographics", "tabular", "tof_voxel"]:
+    for key in ["windows", "demographics", "tabular", "tof_voxel", "tof_windows"]:
         np.testing.assert_allclose(result[key], out[key])


### PR DESCRIPTION
## Summary
- implement `create_tof_windows_with_info` for sliding windows on ToF voxel tensors
- add `ToFWindowBuilder` with caching
- integrate `ToFWindowBuilder` into `Preprocessor`
- update tests for new windows and cache behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687375cda9a48328b13a1009972484a7