### PR TITLE
Fix missing value handling without sensor_cols config

### DIFF
--- a/src/utils/pipeline.py
+++ b/src/utils/pipeline.py
@@ -362,21 +362,25 @@ class Preprocessor:
         X_clean = X_sensor.copy()
         
         # センサー別の処理
-        sensor_config = self.config.get("sensor_cols", [])
+        sensor_config = self.win_builder.sensor_cols
         acc_cols = self.config.get("sensor_acc_cols", [])
         rot_cols = self.config.get("sensor_rot_cols", [])
         thm_cols = self.config.get("sensor_thm_cols", [])
+
+        acc_indices = []
+        rot_indices = []
+        thm_indices = []
         
         # Accelerometer: 0で置換（物理的に正当）
         if acc_cols:
-            acc_indices = [i for i, col in enumerate(sensor_config) if col in acc_cols]
+            acc_indices = [sensor_config.index(col) for col in acc_cols if col in sensor_config]
             for idx in acc_indices:
                 if idx < X_clean.shape[-1]:
                     X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=0.0)
         
         # Rotation: 単位クォータニオンで置換
         if rot_cols:
-            rot_indices = [i for i, col in enumerate(sensor_config) if col in rot_cols]
+            rot_indices = [sensor_config.index(col) for col in rot_cols if col in sensor_config]
             for i, idx in enumerate(rot_indices):
                 if idx < X_clean.shape[-1]:
                     if i == 0:  # w成分
@@ -386,7 +390,7 @@ class Preprocessor:
         
         # Thermal: 前後の値で補間（簡易版）
         if thm_cols:
-            thm_indices = [i for i, col in enumerate(sensor_config) if col in thm_cols]
+            thm_indices = [sensor_config.index(col) for col in thm_cols if col in sensor_config]
             for idx in thm_indices:
                 if idx < X_clean.shape[-1]:
                     # 時系列方向で補間

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -118,3 +118,76 @@ def test_preprocessor_cache_and_transform(tmp_path: Path):
     out = loaded.transform(df)
     for key in ["windows", "demographics", "tabular", "tof_voxel", "tof_windows"]:
         np.testing.assert_allclose(result[key], out[key])
+
+
+def test_handle_missing_values_sensor_type(tmp_path: Path):
+    cfg = {
+        "cache_dir": str(tmp_path / "cache"),
+        "preprocessing": {
+            "window_size": 16,
+            "stride": 8,
+            "min_sequence_length": 4,
+            "padding_value": 0.0,
+            "sampling_rate": 50.0,
+            "fft_bands": [(0.5, 2), (2, 5), (5, 10), (10, 20)],
+            "wavelet": "db4",
+            "wavelet_level": 3,
+            "tda_dimension": 1,
+            "tda_bins": 20,
+            "tda_sigma": 0.1,
+            "use_wavelet_features": False,
+            "use_tda_features": False,
+            "tof_depth": 5,
+            "tof_height": 8,
+            "tof_width": 8,
+            "use_world_acc": False,
+        },
+        "sensor_acc_cols": ["acc_x", "acc_y", "acc_z"],
+        "sensor_rot_cols": ["rot_w", "rot_x", "rot_y", "rot_z"],
+        "sensor_thm_cols": ["thm_1", "thm_2", "thm_3", "thm_4", "thm_5"],
+        "demographics_cols": [
+            "adult_child",
+            "age",
+            "sex",
+            "handedness",
+            "height_cm",
+            "shoulder_to_wrist_cm",
+            "elbow_to_wrist_cm",
+        ],
+    }
+
+    df = make_dummy_df(20)
+    df.loc[0, "acc_x"] = np.nan
+    df.loc[0, "rot_w"] = np.nan
+    df.loc[0, "rot_x"] = np.nan
+    df.loc[1, "thm_1"] = np.nan
+
+    pp = Preprocessor(
+        cfg,
+        use_handedness=False,
+        use_basic_cleaning=False,
+        use_interp_cleaning=False,
+    )
+
+    windows = pp.win_builder.build(df)
+    X_sensor = windows[0]
+    sensor_config = pp.win_builder.sensor_cols
+    acc_idx = sensor_config.index("acc_x")
+    rotw_idx = sensor_config.index("rot_w")
+    rotx_idx = sensor_config.index("rot_x")
+    thm_idx = sensor_config.index("thm_1")
+
+    assert np.isnan(X_sensor[0, 0, acc_idx])
+    assert np.isnan(X_sensor[0, 0, rotw_idx])
+    assert np.isnan(X_sensor[0, 0, rotx_idx])
+    assert np.isnan(X_sensor[0, 1, thm_idx])
+
+    X_clean = pp._handle_missing_values_by_sensor_type(X_sensor)
+
+    assert X_clean[0, 0, acc_idx] == 0.0
+    assert X_clean[0, 0, rotw_idx] == 1.0
+    assert X_clean[0, 0, rotx_idx] == 0.0
+
+    thm_series = X_sensor[0, :, thm_idx]
+    expected = np.nan_to_num(thm_series, nan=np.nanmean(thm_series))
+    np.testing.assert_allclose(X_clean[0, :, thm_idx], expected)


### PR DESCRIPTION
## Summary
- derive `sensor_config` from `WindowTensorBuilder.sensor_cols`
- compute per-sensor indices correctly in `_handle_missing_values_by_sensor_type`
- add a regression test for NaN filling when `sensor_cols` is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737ca7ce7c83289d54b82df8993360