### PR TITLE
Remove duplicate CSV reads in preprocessing

### DIFF
--- a/scripts/run_preprocessing.py
+++ b/scripts/run_preprocessing.py
@@ -83,9 +83,6 @@ def main() -> None:
         logger.info("Loading train.csv and test.csv")
         train_df = pd.read_csv(data_dir / "train.csv")
         test_df = pd.read_csv(data_dir / "test.csv")
-        # Load main data
-        train_df = pd.read_csv(data_dir / "train.csv")
-        test_df = pd.read_csv(data_dir / "test.csv")
         logger.info("Fitting Preprocessor")
         
         # Load demographics data and merge


### PR DESCRIPTION
## Summary
- drop redundant `read_csv` calls in `run_preprocessing.py`
- keep preprocessing stable via tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737caafe3c83288dac7bcb450707f2