### PR TITLE
Update ToF3D CNN trainer load_data & add test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install numpy pandas scikit-learn scipy pyyaml joblib tqdm pytest
+          pip install numpy pandas scikit-learn scipy pyyaml joblib tqdm pytest tensorflow
       - name: Run tests
         run: |
           pytest -q

--- a/src/trainers/tof_3d_cnn_trainer.py
+++ b/src/trainers/tof_3d_cnn_trainer.py
@@ -30,32 +30,15 @@ class ToF3DCNNTrainer:
 
     def load_data(self):
         """Load ToF windows and labels."""
-        tof_path = self.preprocessed_dir / "train_tof_voxel.pkl"
+        tof_path = self.preprocessed_dir / "train_tof_windows.pkl"
         label_path = self.preprocessed_dir / "train_labels.pkl"
-        info_path = self.preprocessed_dir / "train_info.pkl"
+
 
         with open(tof_path, "rb") as f:
-            tof_tensor = pickle.load(f)
+            windows = pickle.load(f)
         with open(label_path, "rb") as f:
             labels = pickle.load(f)
-        with open(info_path, "rb") as f:
-            info = pickle.load(f)
-
-        windows = []
-        for meta in info:
-            start = meta.get("start_idx", 0)
-            end = meta.get("end_idx", start + self.window_size)
-            window = tof_tensor[start:end]
-            if window.shape[0] < self.window_size:
-                pad = np.full(
-                    (self.window_size - window.shape[0],) + window.shape[1:],
-                    self.fill_value,
-                    dtype=np.float32,
-                )
-                window = np.concatenate([window, pad], axis=0)
-            windows.append(window)
-
-        X = np.stack(windows).astype(np.float32)
+        X = np.asarray(windows, dtype=np.float32)
         y = np.asarray(labels)
         return X, y
 

--- a/tests/test_tof_3d_cnn_trainer.py
+++ b/tests/test_tof_3d_cnn_trainer.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+import pickle
+import numpy as np
+import pandas as pd
+import sys
+from pathlib import Path as _Path
+
+ROOT = _Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.utils.pipeline import Preprocessor
+from src.trainers.tof_3d_cnn_trainer import ToF3DCNNTrainer
+
+
+def make_dummy_df(n_rows: int = 10) -> pd.DataFrame:
+    data = {
+        "subject": [0] * n_rows,
+        "sequence_id": [0] * n_rows,
+        "sequence_counter": list(range(n_rows)),
+        "gesture": [1] * n_rows,
+        "adult_child": [1] * n_rows,
+        "age": [30] * n_rows,
+        "sex": [1] * n_rows,
+        "handedness": [1] * n_rows,
+        "height_cm": [170] * n_rows,
+        "shoulder_to_wrist_cm": [60] * n_rows,
+        "elbow_to_wrist_cm": [30] * n_rows,
+    }
+    sensor_cols = [
+        "acc_x",
+        "acc_y",
+        "acc_z",
+        "rot_w",
+        "rot_x",
+        "rot_y",
+        "rot_z",
+        "thm_1",
+        "thm_2",
+        "thm_3",
+        "thm_4",
+        "thm_5",
+    ]
+    for c in sensor_cols:
+        data[c] = np.random.randn(n_rows)
+    for d in range(1, 6):
+        for i in range(64):
+            data[f"tof_{d}_v{i}"] = np.random.rand(n_rows)
+    return pd.DataFrame(data)
+
+
+def make_config(tmp_path: Path) -> dict:
+    return {
+        "output_dir": str(tmp_path / "out"),
+        "cache_dir": str(tmp_path / "cache"),
+        "preprocessing": {
+            "window_size": 16,
+            "stride": 8,
+            "min_sequence_length": 4,
+            "padding_value": 0.0,
+            "sampling_rate": 50.0,
+            "fft_bands": [(0.5, 2), (2, 5), (5, 10), (10, 20)],
+            "wavelet": "db4",
+            "wavelet_level": 3,
+            "tda_dimension": 1,
+            "tda_bins": 20,
+            "tda_sigma": 0.1,
+            "use_wavelet_features": False,
+            "use_tda_features": False,
+            "tof_depth": 5,
+            "tof_height": 8,
+            "tof_width": 8,
+            "use_world_acc": False,
+        },
+        "sensor_acc_cols": ["acc_x", "acc_y", "acc_z"],
+        "sensor_rot_cols": ["rot_w", "rot_x", "rot_y", "rot_z"],
+        "sensor_thm_cols": ["thm_1", "thm_2", "thm_3", "thm_4", "thm_5"],
+        "demographics_cols": [
+            "adult_child",
+            "age",
+            "sex",
+            "handedness",
+            "height_cm",
+            "shoulder_to_wrist_cm",
+            "elbow_to_wrist_cm",
+        ],
+    }
+
+
+def test_tof3dcnn_trainer_load_data(tmp_path: Path):
+    cfg = make_config(tmp_path)
+    df = make_dummy_df()
+    pp = Preprocessor(cfg, use_interp_cleaning=False)
+    result = pp.fit_transform(df)
+
+    pre_dir = Path(cfg["output_dir"]) / "exp" / "preprocessed"
+    pre_dir.mkdir(parents=True, exist_ok=True)
+    with open(pre_dir / "train_tof_windows.pkl", "wb") as f:
+        pickle.dump(result["tof_windows"], f)
+    with open(pre_dir / "train_labels.pkl", "wb") as f:
+        pickle.dump(result["labels"], f)
+
+    trainer = ToF3DCNNTrainer(experiment_name="exp")
+    trainer.config = cfg
+    trainer.preprocessed_dir = pre_dir
+    trainer.window_size = cfg["preprocessing"]["window_size"]
+    trainer.fill_value = cfg["preprocessing"]["padding_value"]
+
+    X, y = trainer.load_data()
+    assert X.shape == result["tof_windows"].shape
+    assert y.shape == result["labels"].shape


### PR DESCRIPTION
## Summary
- simplify `ToF3DCNNTrainer.load_data` to read `train_tof_windows.pkl`
- add unit test for `ToF3DCNNTrainer` loading logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737cb72b1c8328ba69c232cee49268