### PR TITLE
Update data loading for MultimodalTrainer

### DIFF
--- a/src/trainers/multimodal_trainer.py
+++ b/src/trainers/multimodal_trainer.py
@@ -48,11 +48,11 @@ class MultimodalTrainer:
                     return pickle.load(f)
             raise FileNotFoundError(f"{name} ファイルが見つかりません")
 
-        X_sensor = _load("X_sensor_windows")
-        X_demo = _load("X_demographics")
-        X_tab = _load("X_tabular")
-        X_tof = _load("X_tof_voxel")
-        y = _load("y")
+        X_sensor = _load("train_windows")
+        X_demo = _load("train_demographics")
+        X_tab = _load("train_tabular")
+        X_tof = _load("train_tof_windows")
+        y = _load("train_labels")
 
         print(f"センサー: {X_sensor.shape}")
         print(f"人口統計: {X_demo.shape}")

--- a/tests/test_multimodal_trainer.py
+++ b/tests/test_multimodal_trainer.py
@@ -1,0 +1,33 @@
+import pickle
+from pathlib import Path as _Path
+import numpy as np
+import sys
+import types
+
+sys.modules.setdefault("tensorflow", types.ModuleType("tensorflow"))
+
+ROOT = _Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.trainers.multimodal_trainer import MultimodalTrainer
+
+def test_multimodal_trainer_load_all_data(tmp_path):
+    pre_dir = tmp_path
+    arrays = {
+        "train_windows": np.random.randn(3, 4, 5).astype(np.float32),
+        "train_demographics": np.random.randn(3, 2).astype(np.float32),
+        "train_tabular": np.random.randn(3, 6).astype(np.float32),
+        "train_tof_windows": np.random.randn(3, 4, 2, 2, 2).astype(np.float32),
+        "train_labels": np.array([0, 1, 0]),
+    }
+    for name, arr in arrays.items():
+        with open(pre_dir / f"{name}.pkl", "wb") as f:
+            pickle.dump(arr, f)
+    trainer = MultimodalTrainer()
+    trainer.data_dir = pre_dir
+    data = trainer.load_all_data()
+    assert data["sensor"].shape == (3, 4, 5)
+    assert data["demographics"].shape == (3, 2)
+    assert data["tabular"].shape == (3, 6)
+    assert data["tof"].shape == (3, 4, 2, 2, 2)
+    assert data["labels"].shape == (3,)


### PR DESCRIPTION
## Summary
- make `MultimodalTrainer` read files created by `run_preprocessing.py`
- load ToF windows from `train_tof_windows.pkl`
- add test covering data loading with a temporary directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737cbbdc0c8328b13c9c139fdbcdcb