### PR TITLE
Update ToF file names in docs

### DIFF
--- a/doc/preprocessing_outputs.md
+++ b/doc/preprocessing_outputs.md
@@ -9,7 +9,7 @@
 | `train_windows.pkl` / `test_windows.pkl` | ウィンドウ化された IMU センサテンソル | `(n_windows, 128, 12)` | GRU/CNN 系モデルの入力 |
 | `train_demographics.pkl` / `test_demographics.pkl` | ウィンドウ単位の Demographics 特徴量 | `(n_windows, 7)` | 時系列モデルとの結合用 |
 | `train_tabular.pkl` / `test_tabular.pkl` | Block A–H,M を統合した Tabular 特徴量 | `(n_windows, 120)` | LightGBM/CatBoost 用 |
-| `train_tof_voxel.pkl` / `test_tof_voxel.pkl` | ToF ピクセルを (T, depth, H, W) へ整形したテンソル | `(time, 5, 8, 8)` | ToF 3D CNN 用 |
+| `train_tof_windows.pkl` / `test_tof_windows.pkl` (旧 `train_tof_voxel.pkl` / `test_tof_voxel.pkl`) | ToF ピクセルを (T, depth, H, W) へ整形したテンソル | `(time, 5, 8, 8)` | ToF 3D CNN 用 |
 | `train_labels.pkl` / `test_labels.pkl` | 各ウィンドウのラベル ID | `(n_windows,)` | 教師データ |
 | `train_info.pkl` / `test_info.pkl` | `sequence_id` や `start_idx` などのメタ情報 | - | 後続処理用 |
 | `preprocessor.pkl` | 学習済み `Preprocessor` を `Preprocessor.save()` で保存したファイル | - | `Preprocessor.load()` で読み込み |

--- a/doc/preprocessing_usage.md
+++ b/doc/preprocessing_usage.md
@@ -57,7 +57,7 @@ python scripts/run_preprocessing.py \
 
 - `train_windows.pkl` / `test_windows.pkl`
 - `train_tabular.pkl` / `test_tabular.pkl`
-- `train_tof_voxel.pkl` / `test_tof_voxel.pkl`
+- `train_tof_windows.pkl` / `test_tof_windows.pkl` (旧 `train_tof_voxel.pkl` / `test_tof_voxel.pkl`)
 - `preprocessor.pkl` : 学習済み前処理器
 
 ## 5. コードからの利用例

--- a/notebooks/preprocessing_validation.ipynb
+++ b/notebooks/preprocessing_validation.ipynb
@@ -82,13 +82,13 @@
             "  test_info.pkl: 0.00 MB\n",
             "  test_labels.pkl: 0.00 MB\n",
             "  test_tabular.pkl: 0.00 MB\n",
-            "  test_tof_voxel.pkl: 0.13 MB\n",
+            "  test_tof_windows.pkl: 0.13 MB\n",
             "  test_windows.pkl: 0.01 MB\n",
             "  train_demographics.pkl: 0.22 MB\n",
             "  train_info.pkl: 0.29 MB\n",
             "  train_labels.pkl: 1.34 MB\n",
             "  train_tabular.pkl: 8.21 MB\n",
-            "  train_tof_voxel.pkl: 701.84 MB\n",
+            "  train_tof_windows.pkl: 701.84 MB\n",
             "  train_windows.pkl: 48.88 MB\n"
           ]
         }
@@ -148,7 +148,7 @@
         "train_windows = load_pickle(\"train_windows.pkl\")\n",
         "train_demographics = load_pickle(\"train_demographics.pkl\")\n",
         "train_tabular = load_pickle(\"train_tabular.pkl\")\n",
-        "train_tof_voxel = load_pickle(\"train_tof_voxel.pkl\")\n",
+        "train_tof_voxel = load_pickle(\"train_tof_windows.pkl\")\n",
         "train_labels = load_pickle(\"train_labels.pkl\")\n",
         "train_info = load_pickle(\"train_info.pkl\")\n",
         "\n",
@@ -157,7 +157,7 @@
         "test_windows = load_pickle(\"test_windows.pkl\")\n",
         "test_demographics = load_pickle(\"test_demographics.pkl\")\n",
         "test_tabular = load_pickle(\"test_tabular.pkl\")\n",
-        "test_tof_voxel = load_pickle(\"test_tof_voxel.pkl\")\n",
+        "test_tof_voxel = load_pickle(\"test_tof_windows.pkl\")\n",
         "test_labels = load_pickle(\"test_labels.pkl\")\n",
         "test_info = load_pickle(\"test_info.pkl\")\n",
         "\n",


### PR DESCRIPTION
## Summary
- update preprocessing outputs docs to show new ToF filename
- update preprocessing usage docs for new filename
- switch notebook references from *tof_voxel* to *tof_windows*

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742ca9dfcc832895fa09ce058151c7