### PR TITLE
Add NaN check helper and tests

### DIFF
--- a/src/utils/pipeline.py
+++ b/src/utils/pipeline.py
@@ -37,6 +37,16 @@ from .imu import add_world_acc_features
 logger = logging.getLogger(__name__)
 
 
+def validate_no_nan(array: np.ndarray, name: str) -> None:
+    """ArrayにNaNが含まれていないか検証する."""
+    if array is None:
+        return
+    if np.isnan(array).any():
+        msg = f"NaN detected in {name}"
+        logger.error(msg)
+        raise ValueError(msg)
+
+
 class WindowTensorBuilder:
     """Generate IMU window tensors with demographics."""
 
@@ -469,6 +479,13 @@ class Preprocessor:
             tof_tensor.shape,
             tof_windows.shape,
         )
+
+        validate_no_nan(X_sensor_normalized, "windows")
+        validate_no_nan(X_demo_normalized, "demographics")
+        validate_no_nan(tab_normalized, "tabular")
+        validate_no_nan(tof_tensor, "tof_voxel")
+        validate_no_nan(tof_windows, "tof_windows")
+
         return {
             "windows": X_sensor_normalized,
             "demographics": X_demo_normalized,

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 import sys
 from pathlib import Path as _Path
 
@@ -191,3 +192,49 @@ def test_handle_missing_values_sensor_type(tmp_path: Path):
     thm_series = X_sensor[0, :, thm_idx]
     expected = np.nan_to_num(thm_series, nan=np.nanmean(thm_series))
     np.testing.assert_allclose(X_clean[0, :, thm_idx], expected)
+
+
+def test_transform_nan_validation(tmp_path: Path):
+    cfg = {
+        "cache_dir": str(tmp_path / "cache"),
+        "preprocessing": {
+            "window_size": 16,
+            "stride": 8,
+            "min_sequence_length": 4,
+            "padding_value": 0.0,
+            "sampling_rate": 50.0,
+            "fft_bands": [(0.5, 2), (2, 5), (5, 10), (10, 20)],
+            "wavelet": "db4",
+            "wavelet_level": 3,
+            "tda_dimension": 1,
+            "tda_bins": 20,
+            "tda_sigma": 0.1,
+            "use_wavelet_features": False,
+            "use_tda_features": False,
+            "tof_depth": 5,
+            "tof_height": 8,
+            "tof_width": 8,
+            "use_world_acc": False,
+        },
+        "sensor_acc_cols": ["acc_x", "acc_y", "acc_z"],
+        "sensor_rot_cols": ["rot_w", "rot_x", "rot_y", "rot_z"],
+        "sensor_thm_cols": ["thm_1", "thm_2", "thm_3", "thm_4", "thm_5"],
+        "demographics_cols": [
+            "adult_child",
+            "age",
+            "sex",
+            "handedness",
+            "height_cm",
+            "shoulder_to_wrist_cm",
+            "elbow_to_wrist_cm",
+        ],
+    }
+
+    df = make_dummy_df()
+    pp = Preprocessor(cfg, use_interp_cleaning=False)
+    pp.fit(df)
+
+    df_nan = df.copy()
+    df_nan.loc[0, "tof_1_v0"] = np.nan
+    with pytest.raises(ValueError):
+        pp.transform(df_nan)


### PR DESCRIPTION
## Summary
- add helper `validate_no_nan` to check for NaNs
- call helper in `Preprocessor.transform`
- test NaN detection via ToF data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fbb4444c8328beafff0d53b66d84