### PR TITLE
Handle all-NaN thermal windows

### DIFF
--- a/src/utils/pipeline.py
+++ b/src/utils/pipeline.py
@@ -397,8 +397,12 @@ class Preprocessor:
                     for window_idx in range(X_clean.shape[0]):
                         series = X_clean[window_idx, :, idx]
                         if np.isnan(series).any():
-                            # 前後の値で補間
-                            series_clean = np.nan_to_num(series, nan=np.nanmean(series))
+                            if np.isnan(series).all():
+                                fill = getattr(self.win_builder, "padding_value", 0.0)
+                                series_clean = np.full_like(series, fill)
+                            else:
+                                # 前後の値で補間
+                                series_clean = np.nan_to_num(series, nan=np.nanmean(series))
                             X_clean[window_idx, :, idx] = series_clean
         
         # その他のセンサー: 0で置換

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -191,3 +191,60 @@ def test_handle_missing_values_sensor_type(tmp_path: Path):
     thm_series = X_sensor[0, :, thm_idx]
     expected = np.nan_to_num(thm_series, nan=np.nanmean(thm_series))
     np.testing.assert_allclose(X_clean[0, :, thm_idx], expected)
+
+
+def test_thermal_all_nan_replaced(tmp_path: Path):
+    cfg = {
+        "cache_dir": str(tmp_path / "cache"),
+        "preprocessing": {
+            "window_size": 16,
+            "stride": 8,
+            "min_sequence_length": 4,
+            "padding_value": 0.0,
+            "sampling_rate": 50.0,
+            "fft_bands": [(0.5, 2), (2, 5), (5, 10), (10, 20)],
+            "wavelet": "db4",
+            "wavelet_level": 3,
+            "tda_dimension": 1,
+            "tda_bins": 20,
+            "tda_sigma": 0.1,
+            "use_wavelet_features": False,
+            "use_tda_features": False,
+            "tof_depth": 5,
+            "tof_height": 8,
+            "tof_width": 8,
+            "use_world_acc": False,
+        },
+        "sensor_acc_cols": ["acc_x", "acc_y", "acc_z"],
+        "sensor_rot_cols": ["rot_w", "rot_x", "rot_y", "rot_z"],
+        "sensor_thm_cols": ["thm_1", "thm_2", "thm_3", "thm_4", "thm_5"],
+        "demographics_cols": [
+            "adult_child",
+            "age",
+            "sex",
+            "handedness",
+            "height_cm",
+            "shoulder_to_wrist_cm",
+            "elbow_to_wrist_cm",
+        ],
+    }
+
+    df = make_dummy_df(20)
+
+    pp = Preprocessor(
+        cfg,
+        use_handedness=False,
+        use_basic_cleaning=False,
+        use_interp_cleaning=False,
+    )
+
+    windows = pp.win_builder.build(df)
+    X_sensor = windows[0]
+    thm_idx = pp.win_builder.sensor_cols.index("thm_1")
+
+    # fill entire window with NaNs
+    X_sensor[0, :, thm_idx] = np.nan
+
+    X_clean = pp._handle_missing_values_by_sensor_type(X_sensor)
+
+    assert not np.isnan(X_clean[0, :, thm_idx]).any()


### PR DESCRIPTION
## Summary
- fix NaN handling for thermal sensors in pipeline
- when entire thermal series is NaN, replace with padding value
- test that preprocessing clean-up works on all-NaN thermal windows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874fbac98bc83289f216864763b4084