### PR TITLE
Update multimodal flow doc

### DIFF
--- a/doc/multimodal_training_flow_jp.md
+++ b/doc/multimodal_training_flow_jp.md
@@ -45,6 +45,11 @@ ToF 用の 3D-CNN をそれぞれタワーとして構築し、最後に結合�
 学習後、モデルは `output/experiments/<experiment_name>/models/multimodal_model.keras`
 として保存されます。学習履歴は `MultimodalTrainer.history` プロパティから取得できます。
 
+また、実験ディレクトリには次のファイルが生成されます。
+- `models/` ディレクトリ: 学習済みモデル
+- `results/` ディレクトリ: `training_history.json` と `evaluation_results.json`
+これらの履歴ファイルは `src/scripts/visualize_training_history.py` を使って可視化できます。
+
 ## 6. 推論・評価
 `evaluate()` を呼び出すとテストデータに対する Macro F1 が計算されます。
 予測値を保存して Kaggle 形式に変換することで提出ファイルを作成できます。


### PR DESCRIPTION
## Summary
- describe saved model and history files for multimodal training
- mention visualize_training_history.py usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687746fb8a248328bf733fe76b1754fa