### PR TITLE
Add StratifiedGroupKFold support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ CMIコンペ（CMI-Detect-Behavor-with-Sensor-Data）のベースライン実装
 - **利き手補正**: 左右利きの違いを考慮したセンサーデータの正規化
 - **前処理**: 欠損値補完、標準化、特徴量抽出
 - **ベースラインモデル**: LightGBMを使用したマルチクラス分類
-- **クロスバリデーション**: 5分割StratifiedKFold
+- **クロスバリデーション**: 5分割StratifiedGroupKFold（同一被験者のデータが学習と検証に跨らないよう分割）
 - **自動実行**: 前処理から提出ファイル作成まで一括実行
 
 ## 🚀 クイックスタート
@@ -142,9 +142,10 @@ params = {
 }
 ```
 
-### クロスバリデーション
+-### クロスバリデーション
 
-- **5分割StratifiedKFold**
+- **5分割StratifiedGroupKFold**
+  - 同一被験者（または sequence_id）が学習と検証に跨らないように分割し、データリークを防止します。
 - **Early Stopping**: 50ラウンド
 - **評価指標**: F1-Score (macro average)
 

--- a/src/trainers/multimodal_trainer_v30.py
+++ b/src/trainers/multimodal_trainer_v30.py
@@ -13,7 +13,10 @@ from pathlib import Path
 from typing import Any, Dict
 
 import numpy as np
-from sklearn.model_selection import train_test_split, StratifiedKFold
+from sklearn.model_selection import (
+    train_test_split,
+    StratifiedGroupKFold,
+)
 from sklearn.metrics import classification_report, f1_score
 
 from src.utils.cmi_evaluation import calculate_cmi_score
@@ -61,7 +64,11 @@ class MultimodalTrainer:
         return y
 
     def load_all_data(self) -> Dict[str, np.ndarray]:
-        """各モダリティの前処理済みデータをすべて読み込む"""
+        """各モダリティの前処理済みデータをすべて読み込む
+
+        追加で ``train_info.pkl`` を読み込み、``subject`` または ``sequence_id``
+        の配列を ``groups`` キーで返す。
+        """
         print("前処理済みデータを読み込み中...")
 
         def _load(name: str) -> np.ndarray:
@@ -79,12 +86,22 @@ class MultimodalTrainer:
         X_tab = _load("train_tabular")
         X_tof = _load("train_tof_windows")
         y = _load("train_labels")
+        info = _load("train_info")
+
+        if isinstance(info, list) and len(info) > 0 and isinstance(info[0], dict):
+            groups = np.array([
+                d.get("subject") if d.get("subject") is not None else d.get("sequence_id")
+                for d in info
+            ])
+        else:
+            groups = np.asarray(info)
 
         print(f"センサー: {X_sensor.shape}")
         print(f"人口統計: {X_demo.shape}")
         print(f"表形式: {X_tab.shape}")
         print(f"ToF: {X_tof.shape}")
         print(f"ラベル: {y.shape}")
+        print(f"グループ数: {len(groups)}")
 
         return {
             "sensor": X_sensor,
@@ -92,6 +109,7 @@ class MultimodalTrainer:
             "tabular": X_tab,
             "tof": X_tof,
             "labels": y,
+            "groups": groups,
         }
 
     def build_multimodal_model(
@@ -216,8 +234,9 @@ class MultimodalTrainer:
         epochs: int = 50,
         batch_size: int = 32,
         n_splits: int = 5,
+        groups: np.ndarray | None = None,
     ) -> Dict[str, Any]:
-        """StratifiedKFold を用いたクロスバリデーション学習"""
+        """StratifiedGroupKFold を用いたクロスバリデーション学習"""
         print("=== データ型確認 ===")
         print(f"X_sensor dtype: {data['sensor'].dtype}")
         print(f"X_demo dtype: {data['demographics'].dtype}")
@@ -232,10 +251,13 @@ class MultimodalTrainer:
         X_f = data["tof"]
         y = data["labels"]
 
-        skf = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
+        if groups is None:
+            groups = data.get("groups")
+
+        skf = StratifiedGroupKFold(n_splits=n_splits, shuffle=True, random_state=42)
         fold_scores: list[float] = []
 
-        for fold, (tr_idx, val_idx) in enumerate(skf.split(np.arange(len(y)), y), 1):
+        for fold, (tr_idx, val_idx) in enumerate(skf.split(np.arange(len(y)), y, groups), 1):
             print(f"Fold {fold}/{n_splits}")
             model, history, f1 = self._train_fold(
                 X_s,

--- a/src/trainers/tabular_trainer.py
+++ b/src/trainers/tabular_trainer.py
@@ -10,7 +10,7 @@ LightGBM と CatBoost を用いた Tabular 特徴量の学習管理を行う。
 from pathlib import Path
 
 import numpy as np
-from sklearn.model_selection import StratifiedKFold
+from sklearn.model_selection import StratifiedGroupKFold
 from sklearn.metrics import f1_score
 
 import lightgbm as lgb
@@ -57,13 +57,13 @@ class TabularModelTrainer:
         print(f"クラス数: {self.n_classes}")
         return X, y, label_encoder
 
-    def train_lightgbm(self, n_folds: int = 5):
+    def train_lightgbm(self, n_folds: int = 5, groups=None):
         """LightGBM を用いた学習とモデル保存"""
         X, y, le = self.load_data()
         print("LightGBM 学習開始")
-        skf = StratifiedKFold(n_splits=n_folds, shuffle=True, random_state=42)
+        skf = StratifiedGroupKFold(n_splits=n_folds, shuffle=True, random_state=42)
         models = []
-        for fold, (tr_idx, val_idx) in enumerate(skf.split(X, y), 1):
+        for fold, (tr_idx, val_idx) in enumerate(skf.split(X, y, groups), 1):
             print(f"Fold {fold}/{n_folds}")
             train_ds = lgb.Dataset(X[tr_idx], label=y[tr_idx])
             val_ds = lgb.Dataset(X[val_idx], label=y[val_idx])
@@ -102,13 +102,13 @@ class TabularModelTrainer:
         print("LightGBM 学習完了")
         return models
 
-    def train_catboost(self, n_folds: int = 5):
+    def train_catboost(self, n_folds: int = 5, groups=None):
         """CatBoost を用いた学習とモデル保存"""
         X, y, le = self.load_data()
         print("CatBoost 学習開始")
-        skf = StratifiedKFold(n_splits=n_folds, shuffle=True, random_state=42)
+        skf = StratifiedGroupKFold(n_splits=n_folds, shuffle=True, random_state=42)
         models = []
-        for fold, (tr_idx, val_idx) in enumerate(skf.split(X, y), 1):
+        for fold, (tr_idx, val_idx) in enumerate(skf.split(X, y, groups), 1):
             print(f"Fold {fold}/{n_folds}")
             model = CatBoostClassifier(
                 loss_function="MultiClass",

--- a/src/utils/train_utils.py
+++ b/src/utils/train_utils.py
@@ -8,7 +8,7 @@ baseline_model.pyの拡張版
 import pandas as pd
 import numpy as np
 import lightgbm as lgb
-from sklearn.model_selection import StratifiedKFold
+from sklearn.model_selection import StratifiedGroupKFold
 from sklearn.metrics import f1_score, classification_report, confusion_matrix
 import warnings
 warnings.filterwarnings('ignore')
@@ -44,14 +44,14 @@ def prepare_data(train_features, test_features):
     
     return X_train, y_train_encoded, X_test, le, feature_cols
 
-def train_model_detailed(X_train, y_train, feature_cols, n_folds=5):
+def train_model_detailed(X_train, y_train, feature_cols, n_folds=5, groups=None):
     """LightGBMモデルの訓練（詳細版）"""
     print(f"\n{'-'*50}")
     print("LightGBMモデル訓練開始（詳細版）")
     print(f"{'-'*50}")
     
     # クロスバリデーション設定
-    skf = StratifiedKFold(n_splits=n_folds, shuffle=True, random_state=42)
+    skf = StratifiedGroupKFold(n_splits=n_folds, shuffle=True, random_state=42)
     
     # モデルパラメータ
     params = {
@@ -75,7 +75,7 @@ def train_model_detailed(X_train, y_train, feature_cols, n_folds=5):
     fold_true_labels = []
     fold_importance = []
     
-    for fold, (train_idx, valid_idx) in enumerate(skf.split(X_train, y_train), 1):
+    for fold, (train_idx, valid_idx) in enumerate(skf.split(X_train, y_train, groups), 1):
         print(f"\nFold {fold}/{n_folds}")
         
         X_fold_train, X_fold_valid = X_train.iloc[train_idx], X_train.iloc[valid_idx]

--- a/tests/test_multimodal_trainer_v30.py
+++ b/tests/test_multimodal_trainer_v30.py
@@ -1,0 +1,63 @@
+import pickle
+import sys
+import types
+from pathlib import Path as _Path
+import numpy as np
+
+tf_mod = types.ModuleType("tensorflow")
+keras_mod = types.ModuleType("keras")
+keras_mod.layers = types.ModuleType("layers")
+keras_mod.models = types.ModuleType("models")
+tf_mod.keras = keras_mod
+sys.modules.setdefault("tensorflow", tf_mod)
+sys.modules.setdefault("tensorflow.keras", keras_mod)
+sys.modules.setdefault("tensorflow.keras.layers", keras_mod.layers)
+sys.modules.setdefault("tensorflow.keras.models", keras_mod.models)
+
+ROOT = _Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.trainers.multimodal_trainer_v30 import MultimodalTrainer
+
+
+class DummyModel:
+    def save(self, path):
+        _Path(path).touch()
+
+
+def test_group_based_cv_split(tmp_path):
+    pre_dir = tmp_path
+    arrays = {
+        "train_windows": np.random.randn(4, 1, 1).astype(np.float32),
+        "train_demographics": np.random.randn(4, 1).astype(np.float32),
+        "train_tabular": np.random.randn(4, 1).astype(np.float32),
+        "train_tof_windows": np.random.randn(4, 1, 1, 1, 1).astype(np.float32),
+        "train_labels": np.array([0, 1, 0, 1]),
+        "train_info": [
+            {"subject": 0, "sequence_id": 0},
+            {"subject": 1, "sequence_id": 1},
+            {"subject": 0, "sequence_id": 2},
+            {"subject": 1, "sequence_id": 3},
+        ],
+    }
+    for name, arr in arrays.items():
+        with open(pre_dir / f"{name}.pkl", "wb") as f:
+            pickle.dump(arr, f)
+
+    trainer = MultimodalTrainer()
+    trainer.data_dir = pre_dir
+    trainer.model_dir = tmp_path
+    data = trainer.load_all_data()
+
+    splits = []
+
+    def fake_train_fold(X_s, X_d, X_t, X_f, y, train_idx, val_idx, **kw):
+        splits.append((train_idx, val_idx))
+        return DummyModel(), None, 0.0
+
+    trainer._train_fold = fake_train_fold
+    trainer.train_cross_validation(data, epochs=1, batch_size=1, n_splits=2, groups=data["groups"])
+
+    assert len(splits) == 2
+    for tr_idx, val_idx in splits:
+        assert len(set(data["groups"][tr_idx]).intersection(data["groups"][val_idx])) == 0


### PR DESCRIPTION
## Summary
- load `train_info.pkl` in `multimodal_trainer_v30` and return `groups`
- enable `StratifiedGroupKFold` for multimodal trainer CV
- support grouped CV in `TabularModelTrainer` and utilities
- document new cross-validation approach and purpose
- test group split logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a457782908328a1635352a091148d