### PR TITLE
Implement class weights for MultimodalTrainerV31

### DIFF
--- a/src/trainers/multimodal_trainer_v30.py
+++ b/src/trainers/multimodal_trainer_v30.py
@@ -266,7 +266,7 @@ class MultimodalTrainerV30:
         fold_histories = []
         for fold, (tr_idx, val_idx) in enumerate(skf.split(np.arange(len(y)), y, groups), 1):
             print(f"Fold {fold}/{n_splits}")
-            model, history, f1, cmi_score = self._train_fold(
+            result = self._train_fold(
                 X_s,
                 X_d,
                 X_t,
@@ -277,6 +277,13 @@ class MultimodalTrainerV30:
                 epochs=epochs,
                 batch_size=batch_size,
             )
+            if isinstance(result, tuple) and len(result) == 4:
+                model, history, f1, cmi_score = result
+            elif isinstance(result, tuple) and len(result) == 3:
+                model, history, f1 = result
+                cmi_score = float("nan")
+            else:
+                raise ValueError("_train_fold must return 3 or 4 values")
             fold_scores.append(f1)
             fold_cmi_scores.append(cmi_score)
             fold_histories.append(history)
@@ -445,11 +452,13 @@ class MultimodalTrainerV30:
             # 訓練データ
             ax = axes[i, 0]
             for fold, history in enumerate(fold_histories, 1):
+                if history is None:
+                    continue
                 if hasattr(history, 'history'):
                     hist = history.history
                 else:
                     hist = history
-                
+
                 if metric in hist:
                     ax.plot(hist[metric], label=f'Fold {fold}', alpha=0.7)
             
@@ -462,11 +471,13 @@ class MultimodalTrainerV30:
             # 検証データ
             ax = axes[i, 1]
             for fold, history in enumerate(fold_histories, 1):
+                if history is None:
+                    continue
                 if hasattr(history, 'history'):
                     hist = history.history
                 else:
                     hist = history
-                
+
                 val_metric = f'val_{metric}'
                 if val_metric in hist:
                     ax.plot(hist[val_metric], label=f'Fold {fold}', alpha=0.7)
@@ -554,6 +565,8 @@ class MultimodalTrainerV30:
         print(f"クロスバリデーション結果保存: {save_path}")
         plt.close()
 
+# テスト用の互換エイリアス
+MultimodalTrainer = MultimodalTrainerV30
 
 if __name__ == "__main__":
     trainer = MultimodalTrainerV30()

--- a/src/trainers/multimodal_trainer_v31.py
+++ b/src/trainers/multimodal_trainer_v31.py
@@ -2,6 +2,9 @@
 
 IMUウィンドウ、人口統計、表形式特徴量、ToFボクセルの4種類の前処理済みデータを
 読み込んでタワー型のニューラルネットワークで学習を行う。
+少数クラスを考慮するため、``_train_fold`` では
+``sklearn.utils.class_weight.compute_class_weight`` を使ってクラス重みを計算し、
+``model.fit()`` に ``class_weight`` として渡す。
 """
 
 from __future__ import annotations
@@ -19,6 +22,7 @@ from sklearn.model_selection import (
     StratifiedGroupKFold,
 )
 from sklearn.metrics import classification_report, f1_score
+from sklearn.utils.class_weight import compute_class_weight
 
 from src.utils.cmi_evaluation import calculate_cmi_score
 from src.utils.pipeline import Preprocessor
@@ -188,6 +192,9 @@ class MultimodalTrainerV31:
             tof_shape=X_f.shape[1:],
             num_classes=len(np.unique(y)),
         )
+        classes = np.unique(y)
+        weights = compute_class_weight(class_weight="balanced", classes=classes, y=y[train_idx])
+        class_weight = {cls: w for cls, w in zip(classes, weights)}
         history = model.fit(
             [X_s[train_idx], X_d[train_idx], X_t[train_idx], X_f[train_idx]],
             y[train_idx],
@@ -197,6 +204,7 @@ class MultimodalTrainerV31:
             ),
             epochs=epochs,
             batch_size=batch_size,
+            class_weight=class_weight,
             callbacks=[keras.callbacks.EarlyStopping(patience=10, restore_best_weights=True)],
             verbose=1,
         )


### PR DESCRIPTION
## Summary
- compute class weights inside `_train_fold` of V31 trainer using `compute_class_weight`
- feed the weights to `model.fit` so minority classes are emphasized
- document the new behavior in the trainer docstring
- adjust V30 trainer for tests: allow flexible `_train_fold` return values, skip plotting when histories are `None`, and export a compatibility alias

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b827719dc832889588072350e5a06