### PR TITLE
Add attention fusion option

### DIFF
--- a/src/trainers/multimodal_trainer_v30.py
+++ b/src/trainers/multimodal_trainer_v30.py
@@ -266,7 +266,7 @@ class MultimodalTrainerV30:
         fold_histories = []
         for fold, (tr_idx, val_idx) in enumerate(skf.split(np.arange(len(y)), y, groups), 1):
             print(f"Fold {fold}/{n_splits}")
-            model, history, f1, cmi_score = self._train_fold(
+            result = self._train_fold(
                 X_s,
                 X_d,
                 X_t,
@@ -277,9 +277,15 @@ class MultimodalTrainerV30:
                 epochs=epochs,
                 batch_size=batch_size,
             )
+            if len(result) == 4:
+                model, history, f1, cmi_score = result
+            else:
+                model, history, f1 = result
+                cmi_score = 0.0
             fold_scores.append(f1)
             fold_cmi_scores.append(cmi_score)
-            fold_histories.append(history)
+            if history is not None:
+                fold_histories.append(history)
             
             # モデル保存
             model_path = self.model_dir / f"multimodal_model_v30_fold{fold}.keras"
@@ -565,3 +571,6 @@ if __name__ == "__main__":
         print(results)
     except Exception as e:
         print(f"エラー: {e}")
+
+# テスト互換用エイリアス
+MultimodalTrainer = MultimodalTrainerV30

--- a/src/trainers/multimodal_trainer_v31.py
+++ b/src/trainers/multimodal_trainer_v31.py
@@ -119,6 +119,8 @@ class MultimodalTrainerV31:
         tab_shape: int,
         tof_shape: tuple,
         num_classes: int,
+        *,
+        use_attention: bool = False,
     ) -> keras.Model:
         """タワー型統合ネットワークを構築"""
         # 1. IMU Tower (Bidirectional LSTM)
@@ -142,7 +144,15 @@ class MultimodalTrainerV31:
         x4 = self._resnet_block_3d(x4, filters=32, stride=2)
         x4 = keras.layers.GlobalAveragePooling3D()(x4)
 
-        merged = keras.layers.concatenate([x1, x2, x3, x4])
+        if use_attention:
+            # IMU と ToF 特徴量間でアテンションを計算
+            q = keras.layers.Reshape((1, 64))(keras.layers.Dense(64)(x1))
+            v = keras.layers.Reshape((1, 64))(keras.layers.Dense(64)(x4))
+            attn = keras.layers.MultiHeadAttention(num_heads=4, key_dim=64)(q, v)
+            attn = keras.layers.Flatten()(attn)
+            merged = keras.layers.concatenate([attn, x2, x3])
+        else:
+            merged = keras.layers.concatenate([x1, x2, x3, x4])
         merged = keras.layers.Dense(64, activation="relu")(merged)
         merged = keras.layers.Dropout(0.3)(merged)
         output = keras.layers.Dense(num_classes, activation="softmax")(merged)
@@ -179,6 +189,7 @@ class MultimodalTrainerV31:
         *,
         epochs: int = 50,
         batch_size: int = 32,
+        use_attention: bool = False,
     ) -> tuple[keras.Model, keras.callbacks.History, float, float]:
         """単一foldでモデルを学習しF1スコアを返す"""
         model = self.build_multimodal_model(
@@ -187,6 +198,7 @@ class MultimodalTrainerV31:
             tab_shape=X_t.shape[1],
             tof_shape=X_f.shape[1:],
             num_classes=len(np.unique(y)),
+            use_attention=use_attention,
         )
         history = model.fit(
             [X_s[train_idx], X_d[train_idx], X_t[train_idx], X_f[train_idx]],
@@ -209,7 +221,14 @@ class MultimodalTrainerV31:
         
         return model, history, float(f1), float(cmi_score)
 
-    def train(self, data: Dict[str, np.ndarray], epochs: int = 50, batch_size: int = 32) -> keras.callbacks.History:
+    def train(
+        self,
+        data: Dict[str, np.ndarray],
+        epochs: int = 50,
+        batch_size: int = 32,
+        *,
+        use_attention: bool = False,
+    ) -> keras.callbacks.History:
         print("=== データ型確認 ===")
         print(f"X_sensor dtype: {data['sensor'].dtype}")
         print(f"X_demo dtype: {data['demographics'].dtype}")
@@ -237,6 +256,7 @@ class MultimodalTrainerV31:
             Xs_val,
             epochs=epochs,
             batch_size=batch_size,
+            use_attention=use_attention,
         )
         self.model = model
         self.history = history
@@ -249,6 +269,8 @@ class MultimodalTrainerV31:
         batch_size: int = 32,
         n_splits: int = 5,
         groups: np.ndarray | None = None,
+        *,
+        use_attention: bool = False,
     ) -> Dict[str, Any]:
         """StratifiedGroupKFold を用いたクロスバリデーション学習"""
         print("=== データ型確認 ===")
@@ -285,6 +307,7 @@ class MultimodalTrainerV31:
                 val_idx,
                 epochs=epochs,
                 batch_size=batch_size,
+                use_attention=use_attention,
             )
             fold_scores.append(f1)
             fold_cmi_scores.append(cmi_score)


### PR DESCRIPTION
## Summary
- introduce optional cross-attention between IMU and ToF towers in `MultimodalTrainerV31`
- support `use_attention` flag across training helpers
- improve `MultimodalTrainerV30` for testing compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b82f1a6148328aade72f0c869e3f7