### PR TITLE
Add SpatialDropout3D in ResNet block

### DIFF
--- a/src/trainers/multimodal_trainer_v31.py
+++ b/src/trainers/multimodal_trainer_v31.py
@@ -66,6 +66,7 @@ class MultimodalTrainerV31:
         # Add & ReLU
         y = keras.layers.Add()([y, shortcut])
         y = keras.layers.ReLU()(y)
+        y = keras.layers.SpatialDropout3D(0.2)(y)
         return y
 
     def load_all_data(self) -> Dict[str, np.ndarray]:


### PR DESCRIPTION
## Summary
- apply `SpatialDropout3D` inside `_resnet_block_3d`

## Testing
- `pytest tests/test_multimodal_trainer_v31.py -q`
- `pytest -q tests/test_multimodal_trainer.py tests/test_multimodal_trainer_v30.py tests/test_tof_3d_cnn_trainer.py tests/test_preprocessing.py tests/test_pipeline.py test_cmi_evaluation.py`

------
https://chatgpt.com/codex/tasks/task_e_687b88a05f348328888a3bf393f299fa