### PR TITLE
修正: パイプラインのキャッシュ情報公開とテスト調整

### DIFF
--- a/src/utils/pipeline.py
+++ b/src/utils/pipeline.py
@@ -392,6 +392,16 @@ class Preprocessor:
 
         self._fitted = False
 
+    @property
+    def cache_files(self) -> dict:
+        """Return main cache file paths for each builder."""
+        return {
+            "windows": self.win_builder.cache_file,
+            "tabular": self.tab_builder.cache_file,
+            "tof_voxel": self.tof_builder.cache_file,
+            "tof_windows": self.tof_win_builder.cache_file,
+        }
+
     def _maybe_clean(self, df: pd.DataFrame) -> pd.DataFrame:
         processed = df.copy()
         if self.use_handedness:

--- a/tests/test_multimodal_trainer_v31.py
+++ b/tests/test_multimodal_trainer_v31.py
@@ -77,6 +77,7 @@ def test_build_model_with_attention(monkeypatch):
         "Bidirectional": make_layer("Bidirectional"),
         "Dense": make_layer("Dense"),
         "Add": make_layer("Add"),
+        "Average": make_layer("Average"),
         "Conv3D": make_layer("Conv3D"),
         "BatchNormalization": make_layer("BatchNormalization"),
         "ReLU": make_layer("ReLU"),

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -219,3 +219,6 @@ def test_preprocessor_save_load(tmp_path: Path):
 
     for key in ["windows", "demographics", "tabular", "tof_voxel"]:
         np.testing.assert_allclose(orig[key], out[key])
+
+    for path in pp.cache_files.values():
+        assert path.exists()


### PR DESCRIPTION
## Summary
- add `Average` stub layer in trainer v31 tests
- expose `cache_files` property in `Preprocessor`
- verify cache_files existence in pipeline test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c7ed982308328bdca0de483407248