### PR TITLE
Add run_preprocessing.sh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ python scripts/run_preprocessing.py \
 python src/baseline_model.py
 ```
 
+
+#### `run_preprocessing.sh` を使う
+
+`scripts/run_preprocessing.py` と同等の処理をシェルスクリプトから実行できます。
+スクリプト内で仮想環境の有無をチェックし、有効でない場合は終了します。仮想環境を有効にした状態で次を実行します。
+
+```bash
+bash scripts/run_preprocessing.sh
+```
+
+スクリプト先頭の変数を変更することで実験名や設定ファイルなどを調整できます。
+- `EXPERIMENT_NAME` : 出力フォルダ名
+- `CONFIG_PATH` : 使用する設定ファイル
+- `MODE` : `train` または `predict`
+- `USE_CACHE` : キャッシュを利用するか
+- `AUGMENT_HANDEDNESS` : 利き手反転拡張を行うか
+
 詳細なフロー説明は
 [doc/preprocess/preprocessing_flow_jp.md](doc/preprocess/preprocessing_flow_jp.md)
 および

--- a/doc/preprocess/preprocessing_usage.md
+++ b/doc/preprocess/preprocessing_usage.md
@@ -51,6 +51,22 @@ python scripts/run_preprocessing.py \
 - `--log-file` : ログを保存するファイルパス。省略時は
   `output_dir/<experiment_name>/preprocessed/preprocess.log` に出力されます。
 
+
+### 3.1 `run_preprocessing.sh` の利用
+
+オプション指定をまとめたシェルスクリプト `scripts/run_preprocessing.sh` も用意しています。実行前に仮想環境を有効にしてください。
+
+```bash
+bash scripts/run_preprocessing.sh
+```
+
+ファイル冒頭の変数を編集することで設定を変更できます。
+- `EXPERIMENT_NAME` : 実験名
+- `CONFIG_PATH` : 設定ファイルパス
+- `MODE` : `train` または `predict`
+- `USE_CACHE` : キャッシュを利用するか
+- `AUGMENT_HANDEDNESS` : 利き手反転拡張を行うか
+
 ## 4. 出力ファイル
 
 生成されるファイルの詳細は [preprocessing_outputs.md](preprocessing_outputs.md) を参照してください。主に以下が保存されます。


### PR DESCRIPTION
## Summary
- document `run_preprocessing.sh` usage in README and preprocessing docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_687c7edaed0483289558253b73fdedd8