### PR TITLE
Add missing sensor flag features

### DIFF
--- a/src/utils/pipeline.py
+++ b/src/utils/pipeline.py
@@ -22,6 +22,7 @@ from .preprocessing import (
     clean_sensor_missing_values,
     clean_missing_sensor_data_parallel_disk,
 )
+from .feature_engineering import add_missing_sensor_flags
 from .config_utils import load_config, get_cache_dir
 from .tof import tof_to_voxel_tensor
 from .feature_engineering import (
@@ -195,6 +196,30 @@ class TabularFeatureBuilder:
             )
             feats.append(tda)
             
+        # --- 欠損センサフラグ (per-window mean) ----------------------
+        flag_cols = [
+            c
+            for c in [
+                "missing_flag_imu",
+                "missing_flag_thermal",
+                "missing_flag_tof",
+            ]
+            if c in df.columns
+        ]
+        if flag_cols:
+            grouped = {
+                (s, sid): g[flag_cols].to_numpy(float)
+                for (s, sid), g in df.groupby(["subject", "sequence_id"])
+            }
+            flags = []
+            for m in info:
+                arr = grouped[(m["subject"], m["sequence_id"])]
+                start = m["start_idx"]
+                end = min(m["end_idx"], arr.shape[0])
+                flags.append(arr[start:end].mean(axis=0))
+            flag_array = np.vstack(flags)
+            feats.append(flag_array)
+
         # 最終的なNaN値チェック
         features = np.hstack(feats + [X_demo])
         final_nan_count = np.isnan(features).sum()
@@ -360,10 +385,20 @@ class Preprocessor:
             processed = clean_sensor_missing_values(
                 processed, self.sensor_type_groups
             )
+        # 欠損センサフラグを付与
+        flag_groups = {
+            "missing_flag_imu": self.sensor_type_groups.get("Accelerometer", [])
+            + self.sensor_type_groups.get("Rotation", []),
+            "missing_flag_thermal": self.sensor_type_groups.get("Thermal", []),
+            "missing_flag_tof": self.sensor_type_groups.get("ToF_Sensor", []),
+        }
+        processed = add_missing_sensor_flags(processed, flag_groups)
+
         if self.use_interp_cleaning:
             base_keep = self.config.get("demographics_cols", [])
             # Only include columns that exist in the dataframe
             keep = [col for col in base_keep + ["gesture"] if col in df.columns]
+            keep.extend(flag_groups.keys())
             processed = clean_missing_sensor_data_parallel_disk(
                 processed,
                 sensor_type_groups=self.sensor_type_groups,

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -92,7 +92,7 @@ def test_preprocessor_cache_and_transform(tmp_path: Path):
 
     assert result["windows"].shape == (1, 16, 12)
     assert result["demographics"].shape == (1, 7)
-    assert result["tabular"].shape == (1, 129)
+    assert result["tabular"].shape == (1, 132)
     assert result["tof_voxel"].shape == (len(df), 5, 8, 8)
     assert result["tof_windows"].shape == (1, 16, 5, 8, 8)
     assert result["labels"].shape == (1,)
@@ -191,3 +191,58 @@ def test_handle_missing_values_sensor_type(tmp_path: Path):
     thm_series = X_sensor[0, :, thm_idx]
     expected = np.nan_to_num(thm_series, nan=np.nanmean(thm_series))
     np.testing.assert_allclose(X_clean[0, :, thm_idx], expected)
+
+
+def test_missing_sensor_flags(tmp_path: Path):
+    cfg = {
+        "cache_dir": str(tmp_path / "cache"),
+        "preprocessing": {
+            "window_size": 16,
+            "stride": 8,
+            "min_sequence_length": 4,
+            "padding_value": 0.0,
+            "sampling_rate": 50.0,
+            "fft_bands": [(0.5, 2), (2, 5), (5, 10), (10, 20)],
+            "wavelet": "db4",
+            "wavelet_level": 3,
+            "tda_dimension": 1,
+            "tda_bins": 20,
+            "tda_sigma": 0.1,
+            "use_wavelet_features": False,
+            "use_tda_features": False,
+            "tof_depth": 5,
+            "tof_height": 8,
+            "tof_width": 8,
+            "use_world_acc": False,
+        },
+        "sensor_acc_cols": ["acc_x", "acc_y", "acc_z"],
+        "sensor_rot_cols": ["rot_w", "rot_x", "rot_y", "rot_z"],
+        "sensor_thm_cols": ["thm_1", "thm_2", "thm_3", "thm_4", "thm_5"],
+        "demographics_cols": [
+            "adult_child",
+            "age",
+            "sex",
+            "handedness",
+            "height_cm",
+            "shoulder_to_wrist_cm",
+            "elbow_to_wrist_cm",
+        ],
+    }
+
+    df = make_dummy_df()
+    imu_cols = cfg["sensor_acc_cols"] + cfg["sensor_rot_cols"]
+    thm_cols = cfg["sensor_thm_cols"]
+    tof_cols = [f"tof_{d}_v{i}" for d in range(1, 6) for i in range(64)]
+    df.loc[0, imu_cols] = np.nan
+    df.loc[0, thm_cols] = np.nan
+    df.loc[0, tof_cols] = np.nan
+
+    pp = Preprocessor(cfg, use_interp_cleaning=False)
+    cleaned = pp._maybe_clean(df)
+
+    for col in ["missing_flag_imu", "missing_flag_thermal", "missing_flag_tof"]:
+        assert col in cleaned.columns
+        assert cleaned.loc[0, col]
+
+    result = pp.fit_transform(df)
+    assert result["tabular"].shape[1] == 132


### PR DESCRIPTION
## Summary
- extend `_maybe_clean` to include `add_missing_sensor_flags`
- append per-window missing sensor flags in `TabularFeatureBuilder`
- adjust preprocessing tests and add new case for flag columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6511d4b8832880c89e1412d14ebf