### PR TITLE
Implement autoencoder feature option

### DIFF
--- a/src/utils/pipeline.py
+++ b/src/utils/pipeline.py
@@ -30,6 +30,7 @@ from .feature_engineering import (
     compute_fft_band_energy,
     compute_wavelet_features,
     compute_persistence_image_features_batch,
+    compute_autoencoder_reconstruction_error,
 )
 from .imu import add_world_acc_features
 
@@ -130,6 +131,7 @@ class TabularFeatureBuilder:
         *,
         use_wavelet: bool | None = None,
         use_tda: bool | None = None,
+        autoencoder_model=None,
     ):
         """Return tabular features for each window.
 
@@ -194,6 +196,11 @@ class TabularFeatureBuilder:
                 sigma=self.tda_sigma,
             )
             feats.append(tda)
+        if autoencoder_model is not None:
+            ae_err = compute_autoencoder_reconstruction_error(
+                X_sensor, autoencoder_model
+            ).reshape(len(X_sensor), -1)
+            feats.append(ae_err)
             
         # 最終的なNaN値チェック
         features = np.hstack(feats + [X_demo])
@@ -491,7 +498,13 @@ class Preprocessor:
         # self._debug_nan_values(X_clean, "処理後")
         return X_clean
 
-    def fit(self, df: pd.DataFrame, use_cache: bool = True) -> "Preprocessor":
+    def fit(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> "Preprocessor":
         logger.info("Fitting Preprocessor")
         df_proc = self._maybe_clean(df)
         windows = self.win_builder.build(df_proc, use_cache=use_cache)
@@ -517,7 +530,12 @@ class Preprocessor:
         
         # 表形式特徴量の正規化
         processed_windows = (X_sensor_clean, X_demo, y, windows[3])
-        tab, _, _ = self.tab_builder.build(df_proc, windows=processed_windows, use_cache=use_cache)
+        tab, _, _ = self.tab_builder.build(
+            df_proc,
+            windows=processed_windows,
+            use_cache=use_cache,
+            autoencoder_model=autoencoder_model,
+        )
         tab_clean = np.nan_to_num(tab, nan=0.0)
         self.tab_scaler.fit(tab_clean)
         logger.info("Tabular features shape %s", tab.shape)
@@ -532,7 +550,13 @@ class Preprocessor:
         self._fitted = True
         return self
 
-    def transform(self, df: pd.DataFrame, use_cache: bool = True) -> dict:
+    def transform(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> dict:
         if not self._fitted:
             raise RuntimeError("Preprocessor is not fitted")
         logger.info("Transforming dataframe of shape %s", df.shape)
@@ -553,7 +577,12 @@ class Preprocessor:
         
         # 表形式特徴量の正規化
         processed_windows = (X_sensor_clean, X_demo, y, info)
-        tab, _, _ = self.tab_builder.build(df_proc, windows=processed_windows, use_cache=use_cache)
+        tab, _, _ = self.tab_builder.build(
+            df_proc,
+            windows=processed_windows,
+            use_cache=use_cache,
+            autoencoder_model=autoencoder_model,
+        )
         # nan_count = np.isnan(tab).sum()
         # logger.info(f"NaNの数: {nan_count}")
         # tab_clean = np.nan_to_num(tab, nan=0.0)
@@ -606,9 +635,17 @@ class Preprocessor:
             "info": info,
         }
 
-    def fit_transform(self, df: pd.DataFrame, use_cache: bool = True) -> dict:
-        self.fit(df, use_cache=use_cache)
-        return self.transform(df, use_cache=use_cache)
+    def fit_transform(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> dict:
+        self.fit(df, use_cache=use_cache, autoencoder_model=autoencoder_model)
+        return self.transform(
+            df, use_cache=use_cache, autoencoder_model=autoencoder_model
+        )
 
     def save(self, path: Path) -> None:
         """Save scaler objects and settings to a pickle file."""

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -50,6 +50,11 @@ def make_dummy_df(n_rows: int = 10) -> pd.DataFrame:
     return pd.DataFrame(data)
 
 
+class DummyAE:
+    def predict(self, X, verbose=0):
+        return np.zeros_like(X)
+
+
 def test_preprocessor_cache_and_transform(tmp_path: Path):
     cfg = {
         "cache_dir": str(tmp_path / "cache"),
@@ -88,11 +93,12 @@ def test_preprocessor_cache_and_transform(tmp_path: Path):
 
     df = make_dummy_df()
     pp = Preprocessor(cfg, use_interp_cleaning=False)
-    result = pp.fit_transform(df)
+    ae = DummyAE()
+    result = pp.fit_transform(df, autoencoder_model=ae)
 
     assert result["windows"].shape == (1, 16, 12)
     assert result["demographics"].shape == (1, 7)
-    assert result["tabular"].shape == (1, 129)
+    assert result["tabular"].shape == (1, 130)
     assert result["tof_voxel"].shape == (len(df), 5, 8, 8)
     assert result["tof_windows"].shape == (1, 16, 5, 8, 8)
     assert result["labels"].shape == (1,)
@@ -115,7 +121,7 @@ def test_preprocessor_cache_and_transform(tmp_path: Path):
     pkl = tmp_path / "preproc.pkl"
     pp.save(pkl)
     loaded = Preprocessor.load(pkl)
-    out = loaded.transform(df)
+    out = loaded.transform(df, autoencoder_model=ae)
     for key in ["windows", "demographics", "tabular", "tof_voxel", "tof_windows"]:
         np.testing.assert_allclose(result[key], out[key])
 


### PR DESCRIPTION
## Summary
- add optional autoencoder feature generation in TabularFeatureBuilder
- pass autoencoder_model through Preprocessor fit/transform
- test that reconstruction error is computed using dummy AE model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d65172ac083288958fd8ee7f4094f