### PR TITLE
Add window size variants preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,12 @@ params = {
 
 ### 1. 前処理の実行
 
-```python
-# ノートブック内で実行
-# notebooks/preprocess.ipynb を参照
+前処理はシェルスクリプト `scripts/run_preprocessing.sh` から実行します。実行
+するとウィンドウサイズ64と128の2種類が生成され、それぞれ
+`<experiment>_ws64`、`<experiment>_ws128` というディレクトリに保存されます。
+
+```bash
+bash scripts/run_preprocessing.sh exp1 train
 ```
 
 ### 2. モデル学習

--- a/config/config_v2_ws64.yaml
+++ b/config/config_v2_ws64.yaml
@@ -1,0 +1,66 @@
+data_dir: "data"
+cache_dir: "cache"
+output_dir: "output/experiments"
+
+# preprocessing hyperparameters
+preprocessing:
+  window_size: 64
+  stride: 32
+  min_sequence_length: 20
+  padding_value: 0.0
+  sampling_rate: 50.0
+  fft_bands:
+    - [0.5, 2]
+    - [2, 5]
+    - [5, 10]
+    - [10, 20]
+  wavelet: "db4"
+  wavelet_level: 3
+  tda_dimension: 1
+  tda_bins: 8
+  tda_sigma: 0.1
+  # 各特徴量計算の有無を制御
+  use_wavelet_features: true
+  use_tda_features: true
+  tof_depth: 5
+  tof_height: 8
+  tof_width: 8
+  use_world_acc: true
+  use_handedness_augmentation: false
+
+
+sensor_acc_cols:
+  - acc_x
+  - acc_y
+  - acc_z
+
+sensor_rot_cols:
+  - rot_w
+  - rot_x
+  - rot_y
+  - rot_z
+
+sensor_thm_cols:
+  - thm_1
+  - thm_2
+  - thm_3
+  - thm_4
+  - thm_5
+
+sensor_tof_cols:
+  - tof_1_v0
+# ToFセンサー（5層×64ピクセル）
+# 例: tof_1_v0〜tof_5_v63
+# 下記はPythonで自動展開することを推奨
+# 例: [f"tof_{d}_v{i}" for d in range(1,6) for i in range(64)]
+
+demographics_cols:
+  - adult_child
+  - age
+  - sex
+  - handedness
+  - height_cm
+  - shoulder_to_wrist_cm
+  - elbow_to_wrist_cm
+# 追加のdemographics項目は現状なし
+# 必要に応じて追記する

--- a/doc/preprocess/preprocessing_usage.md
+++ b/doc/preprocess/preprocessing_usage.md
@@ -42,6 +42,14 @@ python scripts/run_preprocessing.py \
     --use-cache
 ```
 
+`run_preprocessing.py` のオプション指定を簡略化したラッパー `scripts/run_preprocessing.sh` も利用できます。実行するとウィンドウサイズ64と128の結果が `<experiment>_ws64`、`<experiment>_ws128` に保存されます。
+
+```bash
+bash scripts/run_preprocessing.sh exp1 train    # 学習と変換
+bash scripts/run_preprocessing.sh exp1 predict  # 変換のみ
+```
+
+
 各オプションの意味は以下の通りです。
 
 - `--config` : YAML 形式の設定ファイル。デフォルトは `config/config_v2.yaml`。

--- a/scripts/run_preprocessing.sh
+++ b/scripts/run_preprocessing.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# 前処理パイプライン実行用スクリプト
+# 使用例:
+#   bash scripts/run_preprocessing.sh exp1 train
+#   bash scripts/run_preprocessing.sh exp1 predict
+set -e
+
+EXPERIMENT_NAME=${1:?実験名を指定してください}
+MODE=${2:-train}
+
+# ウィンドウサイズごとに実行
+for WS in 64 128; do
+    if [ "$WS" = "64" ]; then
+        CONFIG="config/config_v2_ws64.yaml"
+    else
+        CONFIG="config/config_v2.yaml"
+    fi
+
+    python scripts/run_preprocessing.py \
+        --experiment-name "${EXPERIMENT_NAME}_ws${WS}" \
+        --config "$CONFIG" \
+        --use-cache \
+        --mode "$MODE"
+done
+


### PR DESCRIPTION
## Summary
- run preprocessing for both 64 & 128 window sizes via `run_preprocessing.sh`
- add config for 64 length windows
- document new behavior in README and preprocessing usage docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d853e186483289632be7a4f7b054a