### PR TITLE
Add trainer v40 tests and adjust preprocessing expectations

### DIFF
--- a/tests/test_multimodal_trainer_v40.py
+++ b/tests/test_multimodal_trainer_v40.py
@@ -1,0 +1,162 @@
+import pickle
+import sys
+import types
+from pathlib import Path as _Path
+import numpy as np
+import pytest
+
+# minimal tensorflow stub
+tf_mod = types.ModuleType("tensorflow")
+keras_mod = types.ModuleType("keras")
+keras_mod.layers = types.ModuleType("layers")
+keras_mod.models = types.ModuleType("models")
+tf_mod.keras = keras_mod
+sys.modules.setdefault("tensorflow", tf_mod)
+sys.modules.setdefault("tensorflow.keras", keras_mod)
+sys.modules.setdefault("tensorflow.keras.layers", keras_mod.layers)
+sys.modules.setdefault("tensorflow.keras.models", keras_mod.models)
+
+ROOT = _Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+mm = pytest.importorskip("src.trainers.multimodal_trainer_v40")
+from src.trainers.multimodal_trainer_v40 import MultimodalTrainerV40
+
+
+def test_load_all_data_casts_tabular(tmp_path):
+    pre_dir = tmp_path
+    arrays = {
+        "train_windows": np.random.randn(2, 3, 4),
+        "train_demographics": np.random.randn(2, 2),
+        "train_tabular": np.random.randn(2, 5),
+        "train_tof_windows": np.random.randn(2, 1, 1, 1, 1),
+        "train_labels": np.array([0, 1]),
+        "train_info": np.array([0, 1]),
+    }
+    for name, arr in arrays.items():
+        with open(pre_dir / f"{name}.pkl", "wb") as f:
+            pickle.dump(arr, f)
+
+    trainer = MultimodalTrainerV40()
+    trainer.data_dir = pre_dir
+    data = trainer.load_all_data()
+
+    assert data["tabular"].dtype == np.float32
+    np.testing.assert_allclose(data["tabular"], arrays["train_tabular"].astype(np.float32))
+
+    key_map = {
+        "sensor": "train_windows",
+        "demographics": "train_demographics",
+        "tof": "train_tof_windows",
+    }
+    for key, src in key_map.items():
+        np.testing.assert_array_equal(data[key], arrays[src])
+
+    np.testing.assert_array_equal(data["labels"], arrays["train_labels"])
+    np.testing.assert_array_equal(data["groups"], arrays["train_info"])
+
+
+def test_build_model_has_small_lstm(monkeypatch):
+    created = []
+    lstm_units = []
+
+    class DummyTensor:
+        pass
+
+    class BaseLayer:
+        def __init__(self, *args, **kwargs):
+            created.append(self.__class__.__name__)
+
+        def __call__(self, *args, **kwargs):
+            return DummyTensor()
+
+    def make_layer(name):
+        return type(name, (BaseLayer,), {})
+
+    class LSTM(BaseLayer):
+        def __init__(self, units, *args, **kwargs):
+            lstm_units.append(units)
+            super().__init__(units, *args, **kwargs)
+
+    layers = {
+        "Masking": make_layer("Masking"),
+        "LSTM": LSTM,
+        "Bidirectional": make_layer("Bidirectional"),
+        "Dense": make_layer("Dense"),
+        "Add": make_layer("Add"),
+        "Conv3D": make_layer("Conv3D"),
+        "BatchNormalization": make_layer("BatchNormalization"),
+        "ReLU": make_layer("ReLU"),
+        "GlobalAveragePooling3D": make_layer("GlobalAveragePooling3D"),
+        "Reshape": make_layer("Reshape"),
+        "Flatten": make_layer("Flatten"),
+        "MultiHeadAttention": make_layer("MultiHeadAttention"),
+        "Dropout": make_layer("Dropout"),
+        "SpatialDropout3D": make_layer("SpatialDropout3D"),
+    }
+
+    def Input(*args, **kwargs):
+        created.append("Input")
+        return DummyTensor()
+
+    def concatenate(inputs):
+        created.append("concatenate")
+        return DummyTensor()
+
+    for name, cls in layers.items():
+        setattr(keras_mod.layers, name, cls)
+    keras_mod.layers.Input = Input
+    keras_mod.Input = Input
+    mm.keras.Input = Input
+    mm.keras.layers = keras_mod.layers
+    mm.keras.layers.concatenate = concatenate
+    keras_mod.layers.concatenate = concatenate
+
+    class Model:
+        def __init__(self, inputs=None, outputs=None):
+            self.compiled = False
+
+        def compile(self, *args, **kwargs):
+            self.compiled = True
+
+        def summary(self):
+            return "summary"
+
+    keras_mod.models.Model = Model
+    keras_mod.Model = Model
+    mm.keras.models.Model = Model
+    mm.keras.Model = Model
+
+    keras_mod.optimizers = types.ModuleType("optimizers")
+    keras_mod.optimizers.schedules = types.ModuleType("schedules")
+    mm.keras.optimizers = keras_mod.optimizers
+
+    class ExponentialDecay:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class Adam:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    keras_mod.optimizers.schedules.ExponentialDecay = ExponentialDecay
+    keras_mod.optimizers.Adam = Adam
+    mm.keras.optimizers.schedules = keras_mod.optimizers.schedules
+    mm.keras.optimizers.schedules.ExponentialDecay = ExponentialDecay
+    mm.keras.optimizers.Adam = Adam
+
+    trainer = MultimodalTrainerV40()
+    model = trainer.build_multimodal_model(
+        sensor_shape=(2, 3),
+        demo_shape=2,
+        tab_shape=4,
+        tof_shape=(1, 1, 1, 1),
+        num_classes=2,
+        use_attention=True,
+    )
+
+    assert 32 in lstm_units
+    assert "Bidirectional" in created
+    assert isinstance(model, Model)
+    assert model.compiled
+

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -123,7 +123,7 @@ def test_tabular_feature_builder(tmp_path: Path):
     tab_builder = TabularFeatureBuilder(cfg)
     tab, labels, info = tab_builder.build(df, windows=windows)
 
-    assert tab.shape == (1, 129)
+    assert tab.shape == (1, 143)
     assert labels.shape == (1,)
     assert len(info) == 1
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -98,7 +98,7 @@ def test_preprocessor_cache_and_transform(tmp_path: Path):
 
     assert result["windows"].shape == (1, 16, 12)
     assert result["demographics"].shape == (1, 7)
-    assert result["tabular"].shape == (1, 130)
+    assert result["tabular"].shape == (1, 144)
     assert result["tof_voxel"].shape == (len(df), 5, 8, 8)
     assert result["tof_windows"].shape == (1, 16, 5, 8, 8)
     assert result["labels"].shape == (1,)
@@ -251,7 +251,7 @@ def test_missing_sensor_flags(tmp_path: Path):
         assert cleaned.loc[0, col]
 
     result = pp.fit_transform(df)
-    assert result["tabular"].shape[1] == 132
+    assert result["tabular"].shape[1] == 146
 
 
 def test_new_feature_options(tmp_path: Path):
@@ -297,7 +297,7 @@ def test_new_feature_options(tmp_path: Path):
     ae = DummyAE()
     result = pp.fit_transform(df, autoencoder_model=ae)
 
-    assert result["tabular"].shape[1] == 147
+    assert result["tabular"].shape[1] == 161
 
 
 def test_handedness_augmentation(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add `tests/test_multimodal_trainer_v40.py` based on v31 tests
- update feature builder tests to new output shapes
- adjust preprocessing tests for updated tabular feature counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dbd26f4a083288f63570cb263e07d