### PR TITLE
Add v40 inference submission variants

### DIFF
--- a/submissions/v40_128/cmi-2025-demo-submission.ipynb
+++ b/submissions/v40_128/cmi-2025-demo-submission.ipynb
@@ -1,0 +1,362 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "# CMI Behavior Detection with Multimodal V40 (ws128 only)\n",
+        "\n",
+        "This notebook uses a single 5-fold multimodal model (window size 128) for gesture recognition."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2025-07-22 09:02:38.164453: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+            "2025-07-22 09:02:39.573434: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+            "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+            "E0000 00:00:1753142560.060496  608809 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+            "E0000 00:00:1753142560.185875  608809 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+            "W0000 00:00:1753142561.290751  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1753142561.290781  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1753142561.290782  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1753142561.290783  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "2025-07-22 09:02:41.406674: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+            "To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+            "INFO:src.inference_pipeline:Loading configurations...\n",
+            "INFO:src.inference_pipeline:Loading preprocessors...\n",
+            "INFO:utils.pipeline:Loading Preprocessor from preprocessor_64.pkl\n",
+            "INFO:utils.pipeline:Loading Preprocessor from preprocessor_128.pkl\n",
+            "INFO:src.inference_pipeline:Preprocessors loaded successfully.\n",
+            "INFO:src.inference_pipeline:Loading ws64 models...\n",
+            "I0000 00:00:1753142598.792061  608809 gpu_device.cc:2019] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 5660 MB memory:  -> device: 0, name: NVIDIA GeForce RTX 3050, pci bus id: 0000:01:00.0, compute capability: 8.6\n",
+            "INFO:src.inference_pipeline:Loading ws128 models...\n",
+            "INFO:src.inference_pipeline:Loaded 5 ws64 models and 5 ws128 models.\n"
+          ]
+        }
+      ],
+      "source": [
+        "import os\n",
+        "from pathlib import Path\n",
+        "import polars as pl\n",
+        "\n",
+        "import kaggle_evaluation.cmi_inference_server\n",
+        "\n",
+        "from src.inference_pipeline import predict_one\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def predict(sequence: pl.DataFrame, demographics: pl.DataFrame) -> str:\n",
+        "    return predict_one(sequence, demographics)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "INFO:src.inference_pipeline:Starting ensemble inference for one sample.\n",
+            "INFO:src.inference_pipeline:Processing with ws64 preprocessor...\n",
+            "INFO:utils.pipeline:Transforming dataframe of shape (79, 343)\n",
+            "/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/feature_engineering.py:171: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+            "  df[flag] = df[cols].isna().all(axis=1)\n",
+            "/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/feature_engineering.py:171: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+            "  df[flag] = df[cols].isna().all(axis=1)\n",
+            "/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/feature_engineering.py:171: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+            "  df[flag] = df[cols].isna().all(axis=1)\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "fcb1e82527644496a2a063d38d175129",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "interp:   0%|          | 0/1 [00:00<?, ?seq/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "ec76f94576054c2fab51a21ec36db505",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "concat:   0%|          | 0/1 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "INFO:utils.pipeline:Building windows (size=64, stride=32, min_len=20)\n",
+            "INFO:utils.pipeline:Windows shapes: X_sensor=(1, 64, 18), X_demo=(1, 7), y=(1,)\n",
+            "INFO:utils.pipeline:Window tensor shape (1, 64, 18)\n",
+            "INFO:utils.pipeline:Building tabular features (wavelet=True, tda=True, tof_event=False, temp_grad=False)\n",
+            "INFO:utils.pipeline:Tabular features shape (1, 409)\n",
+            "ERROR:src.inference_pipeline:Error in ws64 processing: X has 409 features, but StandardScaler is expecting 392 features as input.\n",
+            "ERROR:grpc._server:Exception calling application: X has 409 features, but StandardScaler is expecting 392 features as input.\n",
+            "Traceback (most recent call last):\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/grpc/_server.py\", line 610, in _call_behavior\n",
+            "    response_or_iterator = behavior(argument, context)\n",
+            "                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/relay.py\", line 354, in Send\n",
+            "    response_payload = _serialize(response_function(*args, **kwargs))\n",
+            "                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/tmp/ipykernel_608809/132370808.py\", line 2, in predict\n",
+            "    return predict_one(sequence, demographics)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/inference_pipeline.py\", line 109, in predict_one\n",
+            "    data_64 = preprocessor_64.transform(combined_df.copy(), use_cache=False)\n",
+            "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/pipeline.py\", line 762, in transform\n",
+            "    tab_normalized = self.tab_scaler.transform(tab_clean)\n",
+            "                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/utils/_set_output.py\", line 157, in wrapped\n",
+            "    data_to_wrap = f(self, X, *args, **kwargs)\n",
+            "                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/preprocessing/_data.py\", line 1006, in transform\n",
+            "    X = self._validate_data(\n",
+            "        ^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/base.py\", line 626, in _validate_data\n",
+            "    self._check_n_features(X, reset=reset)\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/base.py\", line 415, in _check_n_features\n",
+            "    raise ValueError(\n",
+            "ValueError: X has 409 features, but StandardScaler is expecting 392 features as input.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "✅ TDA処理前: NaN値なし\n"
+          ]
+        },
+        {
+          "ename": "GatewayRuntimeError",
+          "evalue": "(<GatewayRuntimeErrorType.SERVER_RAISED_EXCEPTION: 3>, 'X has 409 features, but StandardScaler is expecting 392 features as input.')",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mGatewayRuntimeError\u001b[39m                       Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 17\u001b[39m\n\u001b[32m     10\u001b[39m     inference_server.run_local_gateway(\n\u001b[32m     11\u001b[39m         data_paths=(\n\u001b[32m     12\u001b[39m             \u001b[33m'\u001b[39m\u001b[33m/kaggle/input/cmi-detect-behavior-with-sensor-data/test.csv\u001b[39m\u001b[33m'\u001b[39m,\n\u001b[32m     13\u001b[39m             \u001b[33m'\u001b[39m\u001b[33m/kaggle/input/cmi-detect-behavior-with-sensor-data/test_demographics.csv\u001b[39m\u001b[33m'\u001b[39m,\n\u001b[32m     14\u001b[39m         )\n\u001b[32m     15\u001b[39m     )\n\u001b[32m     16\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m17\u001b[39m     \u001b[43minference_server\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun_local_gateway\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     18\u001b[39m \u001b[43m        \u001b[49m\u001b[43mdata_paths\u001b[49m\u001b[43m=\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     19\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43m../data/split/test.csv\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     20\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43m../data/split/test_demographics.csv\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     21\u001b[39m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     22\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:149\u001b[39m, in \u001b[36mInferenceServer.run_local_gateway\u001b[39m\u001b[34m(self, data_paths, file_share_dir, *args, **kwargs)\u001b[39m\n\u001b[32m    147\u001b[39m     \u001b[38;5;28mself\u001b[39m.gateway.run()\n\u001b[32m    148\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[32m--> \u001b[39m\u001b[32m149\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m err \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    150\u001b[39m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[32m    151\u001b[39m     \u001b[38;5;28mself\u001b[39m.server.stop(\u001b[32m0\u001b[39m)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:147\u001b[39m, in \u001b[36mInferenceServer.run_local_gateway\u001b[39m\u001b[34m(self, data_paths, file_share_dir, *args, **kwargs)\u001b[39m\n\u001b[32m    145\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m    146\u001b[39m     \u001b[38;5;28mself\u001b[39m.gateway = \u001b[38;5;28mself\u001b[39m._get_gateway_for_test(data_paths, file_share_dir, *args, **kwargs)\n\u001b[32m--> \u001b[39m\u001b[32m147\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mgateway\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    148\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[32m    149\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m err \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:105\u001b[39m, in \u001b[36mGateway.run\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    102\u001b[39m     \u001b[38;5;28mself\u001b[39m.write_result(error)\n\u001b[32m    103\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m error:\n\u001b[32m    104\u001b[39m     \u001b[38;5;66;03m# For local testing\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m105\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m error\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:84\u001b[39m, in \u001b[36mGateway.run\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m     82\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m     83\u001b[39m     \u001b[38;5;28mself\u001b[39m.unpack_data_paths()\n\u001b[32m---> \u001b[39m\u001b[32m84\u001b[39m     predictions, row_ids = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mget_all_predictions\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     85\u001b[39m     \u001b[38;5;28mself\u001b[39m.write_submission(predictions, row_ids)\n\u001b[32m     86\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m kaggle_evaluation.core.base_gateway.GatewayRuntimeError \u001b[38;5;28;01mas\u001b[39;00m gre:\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:56\u001b[39m, in \u001b[36mGateway.get_all_predictions\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m     54\u001b[39m all_row_ids = []\n\u001b[32m     55\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m data_batch, row_ids \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.generate_data_batches():\n\u001b[32m---> \u001b[39m\u001b[32m56\u001b[39m     predictions = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mpredict\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43mdata_batch\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     57\u001b[39m     \u001b[38;5;28mself\u001b[39m.validate_prediction_batch(predictions, row_ids)\n\u001b[32m     58\u001b[39m     all_predictions.append(predictions)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:72\u001b[39m, in \u001b[36mGateway.predict\u001b[39m\u001b[34m(self, *args, **kwargs)\u001b[39m\n\u001b[32m     70\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m.client.send(\u001b[33m'\u001b[39m\u001b[33mpredict\u001b[39m\u001b[33m'\u001b[39m, *args, **kwargs)\n\u001b[32m     71\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m---> \u001b[39m\u001b[32m72\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mhandle_server_error\u001b[49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mpredict\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/base_gateway.py:257\u001b[39m, in \u001b[36mBaseGateway.handle_server_error\u001b[39m\u001b[34m(self, exception, endpoint)\u001b[39m\n\u001b[32m    255\u001b[39m     message_match = re.search(\u001b[33m'\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mException calling application: (.*)\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m'\u001b[39m, exception_str, re.IGNORECASE)\n\u001b[32m    256\u001b[39m     message = message_match.group(\u001b[32m1\u001b[39m) \u001b[38;5;28;01mif\u001b[39;00m message_match \u001b[38;5;28;01melse\u001b[39;00m exception_str\n\u001b[32m--> \u001b[39m\u001b[32m257\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m GatewayRuntimeError(GatewayRuntimeErrorType.SERVER_RAISED_EXCEPTION, message) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    258\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(exception, grpc._channel._InactiveRpcError):\n\u001b[32m    259\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m GatewayRuntimeError(GatewayRuntimeErrorType.SERVER_CONNECTION_FAILED, exception_str) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n",
+            "\u001b[31mGatewayRuntimeError\u001b[39m: (<GatewayRuntimeErrorType.SERVER_RAISED_EXCEPTION: 3>, 'X has 409 features, but StandardScaler is expecting 392 features as input.')"
+          ]
+        }
+      ],
+      "source": [
+        "inference_server = kaggle_evaluation.cmi_inference_server.CMIInferenceServer(predict)\n",
+        "\n",
+        "def is_kaggle():\n",
+        "    return \"KAGGLE_URL_BASE\" in os.environ or Path(\"/kaggle\").exists()\n",
+        "\n",
+        "if os.getenv('KAGGLE_IS_COMPETITION_RERUN'):\n",
+        "    inference_server.serve()\n",
+        "else:\n",
+        "    if is_kaggle():\n",
+        "        inference_server.run_local_gateway(\n",
+        "            data_paths=(\n",
+        "                '/kaggle/input/cmi-detect-behavior-with-sensor-data/test.csv',\n",
+        "                '/kaggle/input/cmi-detect-behavior-with-sensor-data/test_demographics.csv',\n",
+        "            )\n",
+        "        )\n",
+        "    else:\n",
+        "        inference_server.run_local_gateway(\n",
+        "            data_paths=(\n",
+        "                '../data/split/test.csv',\n",
+        "                '../data/split/test_demographics.csv',\n",
+        "            )\n",
+        "        )\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Shape: (102, 2)\n",
+            "Columns: ['sequence_id', 'gesture']\n",
+            "First 10 rows:\n",
+            "  sequence_id                    gesture\n",
+            "0  SEQ_060707         Cheek - pinch skin\n",
+            "1  SEQ_037923              Text on phone\n",
+            "2  SEQ_028006   Forehead - pull hairline\n",
+            "3  SEQ_020034      Above ear - pull hair\n",
+            "4  SEQ_016979        Eyebrow - pull hair\n",
+            "5  SEQ_037140      Above ear - pull hair\n",
+            "6  SEQ_062937             Neck - scratch\n",
+            "7  SEQ_025391          Neck - pinch skin\n",
+            "8  SEQ_064204  Pull air toward your face\n",
+            "9  SEQ_063950         Cheek - pinch skin\n",
+            "Value counts:\n",
+            "gesture\n",
+            "Neck - scratch                                20\n",
+            "Cheek - pinch skin                            13\n",
+            "Neck - pinch skin                             13\n",
+            "Text on phone                                 11\n",
+            "Wave hello                                     7\n",
+            "Eyebrow - pull hair                            6\n",
+            "Eyelash - pull hair                            6\n",
+            "Above ear - pull hair                          5\n",
+            "Forehead - scratch                             5\n",
+            "Forehead - pull hairline                       3\n",
+            "Pull air toward your face                      3\n",
+            "Glasses on/off                                 3\n",
+            "Pinch knee/leg skin                            3\n",
+            "Write name in air                              2\n",
+            "Feel around in tray and pull out an object     1\n",
+            "Write name on leg                              1\n",
+            "Name: count, dtype: int64\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Check submission file\n",
+        "import pandas as pd\n",
+        "df = pd.read_parquet('submission.parquet')\n",
+        "print('Shape:', df.shape)\n",
+        "print('Columns:', df.columns.tolist())\n",
+        "print('First 10 rows:')\n",
+        "print(df.head(10))\n",
+        "print('Value counts:')\n",
+        "print(df['gesture'].value_counts())\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "CMI評価指標計算開始...\n",
+            "y_true shape: (102,), y_pred shape: (102,)\n",
+            "ラベル変換完了: 102 samples\n",
+            "データ中のジェスチャー: 18種類\n",
+            "Binary分類 - Target: 64, Non-Target: 38\n",
+            "Binary F1: 0.6963\n",
+            "Macro F1: 0.1124\n",
+            "CMI Score: 0.4044\n",
+            "Test Accuracy: 0.0588\n",
+            "CMI Score: 0.4044, Binary F1: 0.6963, Macro F1: 0.1124, Accuracy: 0.0588\n"
+          ]
+        }
+      ],
+      "source": [
+        "import pandas as pd\n",
+        "from src.utils.cmi_evaluation import calculate_cmi_score\n",
+        "\n",
+        "# 例: 推論結果\n",
+        "df_pred = pd.read_parquet('submission.parquet')  # またはcsv等\n",
+        "# 例: 正解ラベル\n",
+        "df_true = pd.read_csv('../data/split/test_labels.csv')\n",
+        "\n",
+        "# ラベル名が一致している前提\n",
+        "y_pred = df_pred['gesture'].values\n",
+        "y_true = df_true['gesture'].values\n",
+        "\n",
+        "# 必要ならLabelEncoderでエンコード\n",
+        "from sklearn.preprocessing import LabelEncoder\n",
+        "le = LabelEncoder()\n",
+        "le.fit(list(y_true) + list(y_pred))\n",
+        "y_true_enc = le.transform(y_true)\n",
+        "y_pred_enc = le.transform(y_pred)\n",
+        "\n",
+        "# CMIスコア計算\n",
+        "cmi_score, binary_f1, macro_f1, test_acc = calculate_cmi_score(y_pred_enc, y_true_enc, label_encoder=le, verbose=True)\n",
+        "print(f'CMI Score: {cmi_score:.4f}, Binary F1: {binary_f1:.4f}, Macro F1: {macro_f1:.4f}, Accuracy: {test_acc:.4f}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Target / Non‑target 比率 (%)\n",
+            "sequence_type  Non-Target  Target\n",
+            "fold                             \n",
+            "0                    39.7    60.3\n",
+            "1                    40.4    59.6\n",
+            "2                    40.3    59.7\n",
+            "3                    40.4    59.6\n",
+            "4                    40.0    60.0\n"
+          ]
+        }
+      ],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.5"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/submissions/v40_128/config_ws128.yaml
+++ b/submissions/v40_128/config_ws128.yaml
@@ -1,0 +1,1 @@
+../../config/config_v40_ws128.yaml

--- a/submissions/v40_128/models_128
+++ b/submissions/v40_128/models_128
@@ -1,0 +1,1 @@
+../../output/experiments/preprocess_v2_ws128/models

--- a/submissions/v40_128/prepare.sh
+++ b/submissions/v40_128/prepare.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Create necessary directories
+mkdir -p src/utils
+mkdir -p src/trainers
+
+# Copy essential source files
+cp -p ../../src/utils/pipeline.py ./src/utils/
+cp -p ../../src/utils/kaggle.py ./src/utils/
+cp -p ../../src/utils/cmi_evaluation.py ./src/utils/
+cp -p ../../src/utils/config_utils.py ./src/utils/
+cp -p ../../src/trainers/multimodal_trainer_v40.py ./src/trainers/
+cp -p ../../src/utils/preprocessing.py ./src/utils/
+cp -p ../../src/utils/tof.py ./src/utils/
+cp -p ../../src/utils/imu.py ./src/utils/
+cp -p ../../src/utils/feature_engineering.py ./src/utils/
+cp -p ../../src/utils/io_utils.py ./src/utils/
+
+# Link ws128 model and preprocessor
+ln -s ../../output/experiments/preprocess_v2_ws128/models models_128
+ln -s ../../output/experiments/preprocess_v2_ws128/preprocessed/preprocessor.pkl preprocessor_128.pkl
+
+# Link config file
+ln -s ../../config/config_v40_ws128.yaml config_ws128.yaml
+
+# Create a dummy kaggle_evaluation link if it doesn't exist, for local testing
+if [ ! -d "kaggle_evaluation" ]; then
+    ln -s ../../data/kaggle_evaluation kaggle_evaluation
+fi

--- a/submissions/v40_128/src/inference_pipeline.py
+++ b/submissions/v40_128/src/inference_pipeline.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+import numpy as np
+import polars as pl
+import pandas as pd
+import tensorflow as tf
+import logging
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from utils.pipeline import Preprocessor
+from utils.config_utils import load_config
+from utils.kaggle import is_kaggle
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def load_model_and_preprocessor():
+    """Load ws128 model and preprocessor."""
+    if is_kaggle():
+        base_path = Path("/kaggle/input/cmi-v40-ws128")
+        models_dir = base_path / "models_128"
+        preprocessor_path = base_path / "preprocessor_128.pkl"
+        config_path = base_path / "config_ws128.yaml"
+    else:
+        models_dir = Path("models_128")
+        preprocessor_path = Path("preprocessor_128.pkl")
+        config_path = Path("config_ws128.yaml")
+
+    logger.info("Loading configuration...")
+    config = load_config(config_path) if config_path.exists() else None
+
+    logger.info("Loading preprocessor...")
+    preprocessor = Preprocessor.load(preprocessor_path)
+    if config:
+        preprocessor.config.update(config)
+
+    logger.info("Loading models...")
+    models = []
+    for fold in range(1, 6):
+        model_path = models_dir / f"multimodal_model_v40_fold{fold}.keras"
+        if model_path.exists():
+            models.append(tf.keras.models.load_model(model_path))
+        else:
+            raise FileNotFoundError(f"Model not found: {model_path}")
+    logger.info(f"Loaded {len(models)} ws128 models.")
+    return preprocessor, models
+
+
+preprocessor, models = load_model_and_preprocessor()
+
+
+def predict_one(sequence: pl.DataFrame, demographics: pl.DataFrame) -> str:
+    """Run inference using ws128 model set."""
+    seq_df = sequence.to_pandas()
+    demo_df = demographics.to_pandas()
+    combined_df = seq_df.merge(demo_df, on="subject", how="left")
+
+    data = preprocessor.transform(combined_df.copy(), use_cache=False)
+    inputs = [
+        data["windows"],
+        data["demographics"],
+        data["tabular"],
+        data["tof_windows"],
+    ]
+
+    preds = [model.predict(inputs, verbose=0) for model in models]
+    avg_pred = np.mean(preds, axis=0)
+
+    label_index = np.argmax(avg_pred, axis=1)[0]
+    if hasattr(preprocessor, "label_encoder") and preprocessor.label_encoder is not None:
+        return preprocessor.label_encoder.inverse_transform([label_index])[0]
+    return f"gesture_{label_index}"

--- a/submissions/v40_128/src/trainers/multimodal_trainer_v40.py
+++ b/submissions/v40_128/src/trainers/multimodal_trainer_v40.py
@@ -1,0 +1,614 @@
+"""多モダリティ学習用トレーナー
+
+IMUウィンドウ、人口統計、表形式特徴量、ToFボクセルの4種類の前処理済みデータに加え、
+ToFイベント特徴量や温度勾配特徴量などの拡張タブular特徴量を利用して学習を行う。
+少数クラスを考慮するため、``_train_fold`` では
+``sklearn.utils.class_weight.compute_class_weight`` を使ってクラス重みを計算し、
+``model.fit()`` に ``class_weight`` として渡す。
+"""
+
+from __future__ import annotations
+
+import os
+import json
+import pickle
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.model_selection import (
+    train_test_split,
+    StratifiedGroupKFold,
+)
+from sklearn.metrics import classification_report, f1_score
+from sklearn.utils.class_weight import compute_class_weight
+
+from src.utils.cmi_evaluation import calculate_cmi_score
+from src.utils.pipeline import Preprocessor
+import tensorflow as tf
+from tensorflow import keras
+
+
+class MultimodalTrainerV40:
+    """多モダリティモデル学習管理クラス（v40）"""
+
+    def __init__(self, experiment_name: str = "multimodal") -> None:
+        self.experiment_name = experiment_name
+        self.base_dir = Path("output/experiments") / experiment_name
+        self.data_dir = self.base_dir / "preprocessed"
+        self.model_dir = self.base_dir / "models"
+        self.result_dir = self.base_dir / "results"
+
+        self.model_dir.mkdir(parents=True, exist_ok=True)
+        self.result_dir.mkdir(parents=True, exist_ok=True)
+
+        print(f"Experiment name: {self.experiment_name}")
+        print(f"Data directory: {self.data_dir}")
+
+    def _resnet_block_3d(self, x: tf.Tensor, filters: int, kernel_size: int = 3, stride: int = 1) -> tf.Tensor:
+        """3D ResNet ブロック"""
+        shortcut = x
+
+        # メインパス
+        y = keras.layers.Conv3D(filters, kernel_size, strides=stride, padding="same")(x)
+        y = keras.layers.BatchNormalization()(y)
+        y = keras.layers.ReLU()(y)
+
+        y = keras.layers.Conv3D(filters, kernel_size, padding="same")(y)
+        y = keras.layers.BatchNormalization()(y)
+
+        # ショートカットパス
+        if stride != 1 or x.shape[-1] != filters:
+            shortcut = keras.layers.Conv3D(filters, 1, strides=stride, padding="same")(shortcut)
+            shortcut = keras.layers.BatchNormalization()(shortcut)
+
+        # Add & ReLU
+        y = keras.layers.Add()([y, shortcut])
+        y = keras.layers.ReLU()(y)
+        y = keras.layers.SpatialDropout3D(0.2)(y)
+        return y
+
+    def load_all_data(self) -> Dict[str, np.ndarray]:
+        """各モダリティの前処理済みデータをすべて読み込む
+
+        追加で ``train_info.pkl`` を読み込み、``subject`` または ``sequence_id``
+        の配列を ``groups`` キーで返す。
+        """
+        print("前処理済みデータを読み込み中...")
+
+        def _load(name: str) -> np.ndarray:
+            npy = self.data_dir / f"{name}.npy"
+            pkl = self.data_dir / f"{name}.pkl"
+            if npy.exists():
+                return np.load(npy)
+            if pkl.exists():
+                with open(pkl, "rb") as f:
+                    return pickle.load(f)
+            raise FileNotFoundError(f"{name} ファイルが見つかりません")
+
+        X_sensor = _load("train_windows")
+        X_demo = _load("train_demographics")
+        X_tab = _load("train_tabular")
+        X_tab = X_tab.astype(np.float32)
+        X_tof = _load("train_tof_windows")
+        y = _load("train_labels")
+        info = _load("train_info")
+
+        if isinstance(info, list) and len(info) > 0 and isinstance(info[0], dict):
+            groups = np.array([
+                d.get("subject") for d in info
+            ])
+        else:
+            groups = np.asarray(info)
+
+        print(f"センサー: {X_sensor.shape}")
+        print(f"人口統計: {X_demo.shape}")
+        print(f"表形式: {X_tab.shape}")
+        print(f"ToF: {X_tof.shape}")
+        print(f"ラベル: {y.shape}")
+        print(f"グループ数: {len(groups)}")
+
+        return {
+            "sensor": X_sensor,
+            "demographics": X_demo,
+            "tabular": X_tab,
+            "tof": X_tof,
+            "labels": y,
+            "groups": groups,
+        }
+
+    def build_multimodal_model(
+        self,
+        sensor_shape: tuple,
+        demo_shape: int,
+        tab_shape: int,
+        tof_shape: tuple,
+        num_classes: int,
+        *,
+        use_attention: bool = False,
+    ) -> keras.Model:
+        """タワー型統合ネットワークを構築"""
+        # 1. IMU Tower (Bidirectional LSTM)
+        sensor_input = keras.Input(shape=sensor_shape, name="sensor")
+        x1 = keras.layers.Masking()(sensor_input)
+        x1 = keras.layers.Bidirectional(keras.layers.LSTM(32))(x1)
+
+        # 2. Demographics Tower
+        demo_input = keras.Input(shape=(demo_shape,), name="demo")
+        x2 = keras.layers.Dense(32, activation="relu")(demo_input)
+
+        # 3. Tabular Tower (Residual Connection)
+        tab_input = keras.Input(shape=(tab_shape,), name="tabular")
+        x3_base = keras.layers.Dense(64, activation="relu")(tab_input)
+        x3_res = keras.layers.Dense(64, activation="relu")(x3_base)
+        x3 = keras.layers.Add()([x3_base, x3_res])
+
+        # 4. ToF Tower (3D ResNet)
+        tof_input = keras.Input(shape=tof_shape, name="tof")
+        x4 = self._resnet_block_3d(tof_input, filters=16, stride=2)
+        x4 = self._resnet_block_3d(x4, filters=32, stride=2)
+        if use_attention:
+            x4 = keras.layers.SpatialDropout3D(0.2)(x4)
+        x4 = keras.layers.GlobalAveragePooling3D()(x4)
+
+        if use_attention:
+            # IMU と ToF 特徴量間でアテンションを計算
+            q = keras.layers.Reshape((1, 64))(keras.layers.Dense(64)(x1))
+            v = keras.layers.Reshape((1, 64))(keras.layers.Dense(64)(x4))
+            attn = keras.layers.MultiHeadAttention(num_heads=4, key_dim=64)(q, v)
+            attn = keras.layers.Flatten()(attn)
+            merged = keras.layers.concatenate([attn, x2, x3])
+        else:
+            merged = keras.layers.concatenate([x1, x2, x3, x4])
+        merged = keras.layers.Dense(64, activation="relu")(merged)
+        merged = keras.layers.Dropout(0.3)(merged)
+        output = keras.layers.Dense(num_classes, activation="softmax")(merged)
+
+        model = keras.Model(
+            inputs=[sensor_input, demo_input, tab_input, tof_input], outputs=output
+        )
+
+        lr_schedule = keras.optimizers.schedules.ExponentialDecay(
+            initial_learning_rate=1e-3,
+            decay_steps=1000,
+            decay_rate=0.96,
+            staircase=True,
+        )
+        optimizer = keras.optimizers.Adam(learning_rate=lr_schedule)
+
+        model.compile(
+            optimizer=optimizer,
+            loss="sparse_categorical_crossentropy",
+            metrics=["accuracy"],
+        )
+        print(model.summary())
+        return model
+
+    def _train_fold(
+        self,
+        X_s: np.ndarray,
+        X_d: np.ndarray,
+        X_t: np.ndarray,
+        X_f: np.ndarray,
+        y: np.ndarray,
+        train_idx: np.ndarray,
+        val_idx: np.ndarray,
+        *,
+        epochs: int = 50,
+        batch_size: int = 32,
+        use_attention: bool = False,
+    ) -> tuple[keras.Model, keras.callbacks.History, float, float]:
+        """単一foldでモデルを学習しF1スコアを返す"""
+        model = self.build_multimodal_model(
+            sensor_shape=X_s.shape[1:],
+            demo_shape=X_d.shape[1],
+            tab_shape=X_t.shape[1],
+            tof_shape=X_f.shape[1:],
+            num_classes=len(np.unique(y)),
+            use_attention=use_attention,
+        )
+        classes = np.unique(y)
+        weights = compute_class_weight(class_weight="balanced", classes=classes, y=y[train_idx])
+        class_weight = {cls: w for cls, w in zip(classes, weights)}
+        history = model.fit(
+            [X_s[train_idx], X_d[train_idx], X_t[train_idx], X_f[train_idx]],
+            y[train_idx],
+            validation_data=(
+                [X_s[val_idx], X_d[val_idx], X_t[val_idx], X_f[val_idx]],
+                y[val_idx],
+            ),
+            epochs=epochs,
+            batch_size=batch_size,
+            class_weight=class_weight,
+            callbacks=[keras.callbacks.EarlyStopping(patience=10, restore_best_weights=True)],
+            verbose=1,
+        )
+        preds = model.predict([X_s[val_idx], X_d[val_idx], X_t[val_idx], X_f[val_idx]])
+        pred_labels = preds.argmax(axis=1)
+        f1 = f1_score(y[val_idx], pred_labels, average="macro")
+        
+        # CMI-score計算
+        cmi_score, _, _, _ = calculate_cmi_score(pred_labels, y[val_idx])
+        
+        return model, history, float(f1), float(cmi_score)
+
+    def train(
+        self,
+        data: Dict[str, np.ndarray],
+        epochs: int = 50,
+        batch_size: int = 32,
+        *,
+        use_attention: bool = False,
+    ) -> keras.callbacks.History:
+        print("=== データ型確認 ===")
+        print(f"X_sensor dtype: {data['sensor'].dtype}")
+        print(f"X_demo dtype: {data['demographics'].dtype}")
+        print(f"X_tabular dtype: {data['tabular'].dtype}")
+        print(f"X_tof dtype: {data['tof'].dtype}")
+        print(f"y dtype: {data['labels'].dtype}")
+        print(f"y unique values: {np.unique(data['labels'])}")        
+
+        X_s = data["sensor"]
+        X_d = data["demographics"]
+        X_t = data["tabular"]
+        X_f = data["tof"]
+        y = data["labels"]
+
+        Xs_train, Xs_val, yd_train, yd_val = train_test_split(
+            np.arange(len(y)), y, test_size=0.2, stratify=y, random_state=42
+        )
+        model, history, _, _ = self._train_fold(
+            X_s,
+            X_d,
+            X_t,
+            X_f,
+            y,
+            Xs_train,
+            Xs_val,
+            epochs=epochs,
+            batch_size=batch_size,
+            use_attention=use_attention,
+        )
+        self.model = model
+        self.history = history
+        return history
+
+    def train_cross_validation(
+        self,
+        data: Dict[str, np.ndarray],
+        epochs: int = 50,
+        batch_size: int = 32,
+        n_splits: int = 5,
+        groups: np.ndarray | None = None,
+        *,
+        use_attention: bool = False,
+    ) -> Dict[str, Any]:
+        """StratifiedGroupKFold を用いたクロスバリデーション学習"""
+        print("=== データ型確認 ===")
+        print(f"X_sensor dtype: {data['sensor'].dtype}")
+        print(f"X_demo dtype: {data['demographics'].dtype}")
+        print(f"X_tabular dtype: {data['tabular'].dtype}")
+        print(f"X_tof dtype: {data['tof'].dtype}")
+        print(f"y dtype: {data['labels'].dtype}")
+        print(f"y unique values: {np.unique(data['labels'])}")
+
+        X_s = data["sensor"]
+        X_d = data["demographics"]
+        X_t = data["tabular"]
+        X_f = data["tof"]
+        y = data["labels"]
+
+        if groups is None:
+            groups = data.get("groups")
+
+        skf = StratifiedGroupKFold(n_splits=n_splits, shuffle=True, random_state=42)
+        fold_scores: list[float] = []
+        fold_cmi_scores: list[float] = []
+
+        fold_histories = []
+        for fold, (tr_idx, val_idx) in enumerate(skf.split(np.arange(len(y)), y, groups), 1):
+            print(f"Fold {fold}/{n_splits}")
+            model, history, f1, cmi_score = self._train_fold(
+                X_s,
+                X_d,
+                X_t,
+                X_f,
+                y,
+                tr_idx,
+                val_idx,
+                epochs=epochs,
+                batch_size=batch_size,
+                use_attention=use_attention,
+            )
+            fold_scores.append(f1)
+            fold_cmi_scores.append(cmi_score)
+            fold_histories.append(history)
+            
+            # モデル保存
+            model_path = self.model_dir / f"multimodal_model_v40_fold{fold}.keras"
+            model.save(model_path)
+            print(f"モデル保存: {model_path}")
+            
+            # 各foldの学習履歴保存
+            history_path = self.result_dir / f"training_history_fold{fold}.json"
+            self._save_history(history, history_path)
+
+        mean_score = float(np.mean(fold_scores))
+        std_score = float(np.std(fold_scores))
+        mean_cmi = float(np.mean(fold_cmi_scores))
+        std_cmi = float(np.std(fold_cmi_scores))
+        cv_results = {
+            "fold_scores": [float(s) for s in fold_scores],
+            "fold_cmi_scores": [float(s) for s in fold_cmi_scores],
+            "mean_f1": mean_score,
+            "std_f1": std_score,
+            "mean_cmi": mean_cmi,
+            "std_cmi": std_cmi,
+        }
+
+        results_dir = Path("results")
+        results_dir.mkdir(exist_ok=True)
+        with open(results_dir / "cv_results.json", "w", encoding="utf-8") as f:
+            json.dump(cv_results, f, ensure_ascii=False, indent=2)
+        print(f"Cross-validation results saved: {results_dir / 'cv_results.json'}")
+
+        self.cv_results = cv_results
+        
+        # 学習曲線とクロスバリデーション結果をプロット
+        self.plot_training_curves(fold_histories)
+        self.plot_cross_validation_results(cv_results)
+        
+        # 最後のfoldのモデルをself.modelにセット
+        self.model = model
+        
+        return cv_results
+
+    def evaluate(
+        self,
+        data: Dict[str, np.ndarray],
+        *,
+        preprocessor_path: str | Path | None = None,
+    ) -> Dict[str, Any]:
+        X_s = data["sensor"]
+        X_d = data["demographics"]
+        X_t = data["tabular"]
+        X_f = data["tof"]
+        y = data["labels"]
+
+        preds = self.model.predict([X_s, X_d, X_t, X_f])
+        pred_labels = preds.argmax(axis=1)
+
+        label_encoder = None
+        if preprocessor_path is None:
+            preprocessor_path = self.data_dir / "preprocessor.pkl"
+        try:
+            pp_path = Path(preprocessor_path)
+            if pp_path.exists():
+                pp = Preprocessor.load(pp_path)
+                label_encoder = getattr(pp, "label_encoder", None)
+        except Exception as e:
+            print(f"label_encoder 読み込み失敗: {e}")
+
+        cmi_score, binary_f1, macro_f1, test_accuracy = calculate_cmi_score(
+            pred_labels,
+            y,
+            label_encoder=label_encoder,
+        )
+
+        report = classification_report(y, pred_labels, output_dict=True)
+
+        results = {
+            "cmi_score": float(cmi_score),
+            "binary_f1": float(binary_f1),
+            "macro_f1": float(macro_f1),
+            "test_accuracy": float(test_accuracy),
+            "report": report,
+        }
+
+        print(
+            f"CMI Score: {cmi_score:.4f} | Binary F1: {binary_f1:.4f} | "
+            f"Macro F1: {macro_f1:.4f} | Acc: {test_accuracy:.4f}"
+        )
+
+        return results
+
+    def save_model(self, path: str | Path | None = None) -> None:
+        save_path: Path
+        if path is None:
+            save_path = self.model_dir / "multimodal_model.keras"
+        else:
+            save_path = Path(path)
+        self.model.save(save_path)
+        print(f"モデル保存: {save_path}")
+
+    def _save_history(self, history, path: Path) -> None:
+        """学習履歴を保存する内部メソッド"""
+        if hasattr(history, "history"):
+            history_dict = history.history
+        else:
+            history_dict = history
+
+        with open(path, "w") as f:
+            json.dump(history_dict, f, indent=2)
+        print(f"学習履歴保存: {path}")
+
+    def save_training_history(self, path: str | Path | None = None) -> Path:
+        save_path: Path
+        if path is None:
+            save_path = self.result_dir / "training_history.json"
+        else:
+            save_path = Path(path)
+
+        if self.history is None:
+            raise ValueError("history is not set")
+
+        self._save_history(self.history, save_path)
+        return save_path
+
+    def save_evaluation_results(
+        self, results: dict, path: str | Path | None = None
+    ) -> None:
+        save_path: Path
+        if path is None:
+            save_path = self.result_dir / "evaluation_results.json"
+        else:
+            save_path = Path(path)
+
+        def _convert(obj: Any):
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+            if isinstance(obj, (np.floating, float)):
+                return float(obj)
+            if isinstance(obj, (np.integer, int)):
+                return int(obj)
+            return obj
+
+        serializable = {k: _convert(v) for k, v in results.items()}
+        with open(save_path, "w", encoding="utf-8") as f:
+            json.dump(serializable, f, ensure_ascii=False, indent=2)
+        print(f"評価結果保存: {save_path}")
+
+    def plot_training_curves(self, fold_histories: list | None = None, save_path: str | Path | None = None) -> None:
+        """学習曲線をプロットして保存する"""
+        if fold_histories is None:
+            if hasattr(self, 'history') and self.history is not None:
+                fold_histories = [self.history]
+            else:
+                print("学習履歴が見つかりません")
+                return
+
+        if save_path is None:
+            save_path = self.result_dir / "training_curves.png"
+        else:
+            save_path = Path(save_path)
+
+        # プロット設定
+        fig, axes = plt.subplots(2, 2, figsize=(15, 10))
+        fig.suptitle('Training Curves (Multimodal Model V40)', fontsize=16)
+
+        metrics = ['loss', 'accuracy']
+        for i, metric in enumerate(metrics):
+            # 訓練データ
+            ax = axes[i, 0]
+            for fold, history in enumerate(fold_histories, 1):
+                if hasattr(history, 'history'):
+                    hist = history.history
+                else:
+                    hist = history
+                
+                if metric in hist:
+                    ax.plot(hist[metric], label=f'Fold {fold}', alpha=0.7)
+            
+            ax.set_title(f'Training {metric.capitalize()}')
+            ax.set_xlabel('Epoch')
+            ax.set_ylabel(metric.capitalize())
+            ax.legend()
+            ax.grid(True, alpha=0.3)
+
+            # 検証データ
+            ax = axes[i, 1]
+            for fold, history in enumerate(fold_histories, 1):
+                if hasattr(history, 'history'):
+                    hist = history.history
+                else:
+                    hist = history
+                
+                val_metric = f'val_{metric}'
+                if val_metric in hist:
+                    ax.plot(hist[val_metric], label=f'Fold {fold}', alpha=0.7)
+            
+            ax.set_title(f'Validation {metric.capitalize()}')
+            ax.set_xlabel('Epoch')
+            ax.set_ylabel(metric.capitalize())
+            ax.legend()
+            ax.grid(True, alpha=0.3)
+
+        plt.tight_layout()
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"学習曲線保存: {save_path}")
+        plt.close()
+
+    def plot_cross_validation_results(self, cv_results: dict | None = None, save_path: str | Path | None = None) -> None:
+        """クロスバリデーション結果をプロットする"""
+        if cv_results is None:
+            if hasattr(self, 'cv_results'):
+                cv_results = self.cv_results
+            else:
+                print("クロスバリデーション結果が見つかりません")
+                return
+
+        if save_path is None:
+            save_path = self.result_dir / "cv_results.png"
+        else:
+            save_path = Path(save_path)
+
+        fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(15, 10))
+        fig.suptitle('Cross-Validation Results', fontsize=16)
+
+        # Fold別F1スコア
+        fold_scores = cv_results.get('fold_scores', [])
+        if fold_scores:
+            ax1.bar(range(1, len(fold_scores) + 1), fold_scores, alpha=0.7, color='blue')
+            ax1.axhline(y=cv_results.get('mean_f1', 0), color='red', linestyle='--', 
+                       label=f'Mean: {cv_results.get("mean_f1", 0):.4f}')
+            ax1.set_xlabel('Fold')
+            ax1.set_ylabel('F1 Score')
+            ax1.set_title('F1 Score by Fold')
+            ax1.legend()
+            ax1.grid(True, alpha=0.3)
+
+        # Fold別CMIスコア
+        fold_cmi_scores = cv_results.get('fold_cmi_scores', [])
+        if fold_cmi_scores:
+            ax2.bar(range(1, len(fold_cmi_scores) + 1), fold_cmi_scores, alpha=0.7, color='green')
+            ax2.axhline(y=cv_results.get('mean_cmi', 0), color='red', linestyle='--', 
+                       label=f'Mean: {cv_results.get("mean_cmi", 0):.4f}')
+            ax2.set_xlabel('Fold')
+            ax2.set_ylabel('CMI Score')
+            ax2.set_title('CMI Score by Fold')
+            ax2.legend()
+            ax2.grid(True, alpha=0.3)
+
+        # F1スコア統計情報
+        mean_f1 = cv_results.get('mean_f1', 0)
+        std_f1 = cv_results.get('std_f1', 0)
+        
+        ax3.text(0.1, 0.8, f'Mean F1: {mean_f1:.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.text(0.1, 0.7, f'Std F1: {std_f1:.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.text(0.1, 0.6, f'Min F1: {min(fold_scores):.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.text(0.1, 0.5, f'Max F1: {max(fold_scores):.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.set_xlim(0, 1)
+        ax3.set_ylim(0, 1)
+        ax3.set_title('F1 Score Statistics')
+        ax3.axis('off')
+
+        # CMIスコア統計情報
+        mean_cmi = cv_results.get('mean_cmi', 0)
+        std_cmi = cv_results.get('std_cmi', 0)
+        
+        ax4.text(0.1, 0.8, f'Mean CMI: {mean_cmi:.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.text(0.1, 0.7, f'Std CMI: {std_cmi:.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.text(0.1, 0.6, f'Min CMI: {min(fold_cmi_scores):.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.text(0.1, 0.5, f'Max CMI: {max(fold_cmi_scores):.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.set_xlim(0, 1)
+        ax4.set_ylim(0, 1)
+        ax4.set_title('CMI Score Statistics')
+        ax4.axis('off')
+
+        plt.tight_layout()
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"クロスバリデーション結果保存: {save_path}")
+        plt.close()
+
+
+if __name__ == "__main__":
+    trainer = MultimodalTrainerV40()
+    try:
+        data = trainer.load_all_data()
+        trainer.train(data, epochs=5)
+        trainer.save_model()
+        results = trainer.evaluate(data)
+        print(results)
+    except Exception as e:
+        print(f"エラー: {e}")

--- a/submissions/v40_128/src/utils/cmi_evaluation.py
+++ b/submissions/v40_128/src/utils/cmi_evaluation.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+CMI Competition Evaluation Module
+
+CMIコンペティション用の評価指標を計算するモジュール
+"""
+
+import numpy as np
+from sklearn.metrics import f1_score, accuracy_score
+
+# ターゲットジェスチャー（刺激行動）
+TARGET_GESTURES = [
+    'Above ear - pull hair',
+    'Cheek - pinch skin', 
+    'Eyebrow - pull hair',
+    'Eyelash - pull hair',
+    'Forehead - pull hairline',
+    'Forehead - scratch',
+    'Neck - pinch skin',
+    'Neck - scratch'
+]
+
+# 非ターゲットジェスチャー（その他の行動）
+NON_TARGET_GESTURES = [
+    'Write name on leg',
+    'Wave hello', 
+    'Glasses on/off',
+    'Text on phone',
+    'Write name in air',
+    'Feel around in tray and pull out an object',
+    'Scratch knee/leg skin',
+    'Pull air toward your face',
+    'Drink from bottle/cup',
+    'Pinch knee/leg skin'
+]
+
+def calculate_cmi_score(y_pred, y_true, label_encoder=None, verbose=False):
+    """
+    CMI コンペティション評価指標の計算
+    
+    Parameters:
+    -----------
+    y_pred : array-like
+        予測ラベル（エンコード済み）
+    y_true : array-like
+        真のラベル（エンコード済み）
+    label_encoder : LabelEncoder, optional
+        ラベルエンコーダー（None の場合は数値ラベルを直接使用）
+    verbose : bool, default=False
+        詳細ログの出力フラグ
+    
+    Returns:
+    --------
+    tuple
+        (CMI スコア, Binary F1, Macro F1, Test Accuracy)
+    """
+    try:
+        if verbose:
+            print(f"CMI評価指標計算開始...")
+            print(f"y_true shape: {np.array(y_true).shape}, y_pred shape: {np.array(y_pred).shape}")
+        
+        # numpy配列に変換
+        y_true = np.array(y_true)
+        y_pred = np.array(y_pred)
+        
+        # Test Accuracy計算
+        test_accuracy = accuracy_score(y_true, y_pred)
+        
+        if label_encoder is not None:
+            # ラベルを元の文字列に変換
+            y_true_str = label_encoder.inverse_transform(y_true)
+            y_pred_str = label_encoder.inverse_transform(y_pred)
+            
+            if verbose:
+                print(f"ラベル変換完了: {len(y_true_str)} samples")
+                unique_gestures = np.unique(np.concatenate([y_true_str, y_pred_str]))
+                print(f"データ中のジェスチャー: {len(unique_gestures)}種類")
+            
+            # 1. Binary F1: Target vs Non-Target
+            y_true_binary = np.array([1 if gesture in TARGET_GESTURES else 0 for gesture in y_true_str])
+            y_pred_binary = np.array([1 if gesture in TARGET_GESTURES else 0 for gesture in y_pred_str])
+            
+            if verbose:
+                print(f"Binary分類 - Target: {np.sum(y_true_binary)}, Non-Target: {np.sum(1-y_true_binary)}")
+            
+            # Zero division回避
+            if len(np.unique(y_true_binary)) == 1 or len(np.unique(y_pred_binary)) == 1:
+                if verbose:
+                    print("Binary分類で単一クラスのみ検出 - F1スコアを0に設定")
+                binary_f1 = 0.0
+            else:
+                binary_f1 = f1_score(y_true_binary, y_pred_binary, average='binary', zero_division='warn')
+            
+            # 2. Macro F1: 全ジェスチャーのマクロF1（非ターゲットは単一クラスに統合）
+            y_true_macro = np.array([gesture if gesture in TARGET_GESTURES else 'non_target' for gesture in y_true_str])
+            y_pred_macro = np.array([gesture if gesture in TARGET_GESTURES else 'non_target' for gesture in y_pred_str])
+            
+            macro_f1 = f1_score(y_true_macro, y_pred_macro, average='macro', zero_division='warn')
+            
+        else:
+            # ラベルエンコーダーがない場合は、マルチクラス分類用のF1スコアを計算
+            if verbose:
+                print("Label encoderなし - マルチクラス分類用F1スコアを計算")
+            
+            # マルチクラス分類ではbinaryは使用できないため、microまたはmacroを使用
+            # ここではmacroを使用（各クラスを平等に扱う）
+            binary_f1 = f1_score(y_true, y_pred, average='macro', zero_division='warn')
+            macro_f1 = f1_score(y_true, y_pred, average='macro', zero_division='warn')
+        
+        # 3. 最終スコア = Binary F1 + Macro F1の平均
+        cmi_score = (binary_f1 + macro_f1) / 2.0
+        
+        if verbose:
+            print(f"Binary F1: {binary_f1:.4f}")
+            print(f"Macro F1: {macro_f1:.4f}")
+            print(f"CMI Score: {cmi_score:.4f}")
+            print(f"Test Accuracy: {test_accuracy:.4f}")
+        
+        return cmi_score, binary_f1, macro_f1, test_accuracy
+        
+    except Exception as e:
+        print(f"CMI評価指標計算でエラー: {str(e)}")
+        import traceback
+        traceback.print_exc()
+        return 0.0, 0.0, 0.0, 0.0
+
+
+def get_target_gestures():
+    """ターゲットジェスチャー一覧を取得"""
+    return TARGET_GESTURES.copy()
+
+
+def get_non_target_gestures():
+    """非ターゲットジェスチャー一覧を取得"""
+    return NON_TARGET_GESTURES.copy()
+
+
+def is_target_gesture(gesture_name):
+    """指定されたジェスチャーがターゲットかどうかを判定"""
+    return gesture_name in TARGET_GESTURES
+
+
+def print_gesture_info():
+    """ジェスチャー情報を出力"""
+    print("=== CMI Competition Gesture Information ===")
+    print(f"Target Gestures ({len(TARGET_GESTURES)}):")
+    for i, gesture in enumerate(TARGET_GESTURES, 1):
+        print(f"  {i:2d}. {gesture}")
+    
+    print(f"\nNon-Target Gestures ({len(NON_TARGET_GESTURES)}):")
+    for i, gesture in enumerate(NON_TARGET_GESTURES, 1):
+        print(f"  {i:2d}. {gesture}")
+    
+    print(f"\nTotal: {len(TARGET_GESTURES) + len(NON_TARGET_GESTURES)} gestures")
+
+
+def add_cmi_metrics_to_history(history_dict, y_true, y_pred, label_encoder=None, verbose=False):
+    """
+    学習履歴辞書にCMI評価指標を追加
+    
+    Parameters:
+    -----------
+    history_dict : dict
+        学習履歴辞書
+    y_true : array-like
+        真のラベル
+    y_pred : array-like
+        予測ラベル
+    label_encoder : LabelEncoder, optional
+        ラベルエンコーダー
+    verbose : bool, default=False
+        詳細ログの出力フラグ
+    
+    Returns:
+    --------
+    dict
+        CMI評価指標が追加された学習履歴辞書
+    """
+    try:
+        # CMI評価指標を計算
+        cmi_score, binary_f1, macro_f1, accuracy = calculate_cmi_score(
+            y_pred, y_true, label_encoder, verbose
+        )
+        
+        # 新しい形式の学習履歴に対応
+        if 'training_metrics' in history_dict and 'validation_metrics' in history_dict:
+            # 新しい詳細形式
+            if 'cmi_score' not in history_dict['training_metrics']:
+                history_dict['training_metrics']['cmi_score'] = []
+            if 'binary_f1' not in history_dict['training_metrics']:
+                history_dict['training_metrics']['binary_f1'] = []
+            if 'macro_f1' not in history_dict['training_metrics']:
+                history_dict['training_metrics']['macro_f1'] = []
+            
+            # 検証データのCMI評価指標も追加（同じ値を使用）
+            if 'cmi_score' not in history_dict['validation_metrics']:
+                history_dict['validation_metrics']['cmi_score'] = []
+            if 'binary_f1' not in history_dict['validation_metrics']:
+                history_dict['validation_metrics']['binary_f1'] = []
+            if 'macro_f1' not in history_dict['validation_metrics']:
+                history_dict['validation_metrics']['macro_f1'] = []
+            
+            # 各エポックに同じ値を追加（実際の学習では各エポックで異なる値になる）
+            epochs = len(history_dict['training_metrics']['loss'])
+            for _ in range(epochs):
+                history_dict['training_metrics']['cmi_score'].append(cmi_score)
+                history_dict['training_metrics']['binary_f1'].append(binary_f1)
+                history_dict['training_metrics']['macro_f1'].append(macro_f1)
+                history_dict['validation_metrics']['cmi_score'].append(cmi_score)
+                history_dict['validation_metrics']['binary_f1'].append(binary_f1)
+                history_dict['validation_metrics']['macro_f1'].append(macro_f1)
+        
+        else:
+            # 古い形式
+            if 'cmi_score' not in history_dict:
+                history_dict['cmi_score'] = []
+            if 'binary_f1' not in history_dict:
+                history_dict['binary_f1'] = []
+            if 'macro_f1' not in history_dict:
+                history_dict['macro_f1'] = []
+            
+            epochs = len(history_dict['loss'])
+            for _ in range(epochs):
+                history_dict['cmi_score'].append(cmi_score)
+                history_dict['binary_f1'].append(binary_f1)
+                history_dict['macro_f1'].append(macro_f1)
+        
+        if verbose:
+            print(f"CMI評価指標を学習履歴に追加しました:")
+            print(f"  CMI Score: {cmi_score:.4f}")
+            print(f"  Binary F1: {binary_f1:.4f}")
+            print(f"  Macro F1: {macro_f1:.4f}")
+            print(f"  Accuracy: {accuracy:.4f}")
+        
+        return history_dict
+        
+    except Exception as e:
+        print(f"CMI評価指標の追加でエラー: {str(e)}")
+        return history_dict
+
+
+def create_cmi_metrics_history(y_true, y_pred, label_encoder=None, verbose=False):
+    """
+    CMI評価指標のみの学習履歴を作成
+    
+    Parameters:
+    -----------
+    y_true : array-like
+        真のラベル
+    y_pred : array-like
+        予測ラベル
+    label_encoder : LabelEncoder, optional
+        ラベルエンコーダー
+    verbose : bool, default=False
+        詳細ログの出力フラグ
+    
+    Returns:
+    --------
+    dict
+        CMI評価指標の学習履歴辞書
+    """
+    try:
+        # CMI評価指標を計算
+        cmi_score, binary_f1, macro_f1, accuracy = calculate_cmi_score(
+            y_pred, y_true, label_encoder, verbose
+        )
+        
+        # 学習履歴辞書を作成
+        history_dict = {
+            'training_metrics': {
+                'cmi_score': [cmi_score],
+                'binary_f1': [binary_f1],
+                'macro_f1': [macro_f1],
+                'accuracy': [accuracy]
+            },
+            'validation_metrics': {
+                'cmi_score': [cmi_score],
+                'binary_f1': [binary_f1],
+                'macro_f1': [macro_f1],
+                'accuracy': [accuracy]
+            },
+            'metadata': {
+                'timestamp': '2025-01-01 00:00:00',
+                'model_config': {
+                    'num_classes': len(np.unique(y_true)),
+                    'label_encoder_used': label_encoder is not None
+                }
+            },
+            'summary': {
+                'final_cmi_score': cmi_score,
+                'final_binary_f1': binary_f1,
+                'final_macro_f1': macro_f1,
+                'final_accuracy': accuracy
+            }
+        }
+        
+        if verbose:
+            print(f"CMI評価指標の学習履歴を作成しました:")
+            print(f"  CMI Score: {cmi_score:.4f}")
+            print(f"  Binary F1: {binary_f1:.4f}")
+            print(f"  Macro F1: {macro_f1:.4f}")
+            print(f"  Accuracy: {accuracy:.4f}")
+        
+        return history_dict
+        
+    except Exception as e:
+        print(f"CMI評価指標の学習履歴作成でエラー: {str(e)}")
+        return {}
+
+
+if __name__ == "__main__":
+    # モジュールテスト
+    print_gesture_info()
+    
+    print("\n" + "="*60)
+    print("CMI評価指標モジュールの使用方法")
+    print("="*60)
+    
+    print("""
+【基本的な使用方法】
+
+1. CMI評価指標の計算:
+   from utils.cmi_evaluation import calculate_cmi_score
+   
+   cmi_score, binary_f1, macro_f1, accuracy = calculate_cmi_score(
+       y_pred, y_true, label_encoder, verbose=True
+   )
+
+2. ターゲットジェスチャーの取得:
+   from utils.cmi_evaluation import get_target_gestures, get_non_target_gestures
+   
+   target_gestures = get_target_gestures()
+   non_target_gestures = get_non_target_gestures()
+
+3. ジェスチャーの判定:
+   from utils.cmi_evaluation import is_target_gesture
+   
+   is_target = is_target_gesture("Above ear - pull hair")
+
+4. 学習履歴にCMI評価指標を追加:
+   from utils.cmi_evaluation import add_cmi_metrics_to_history
+   
+   updated_history = add_cmi_metrics_to_history(
+       history_dict, y_true, y_pred, label_encoder, verbose=True
+   )
+
+【CMI評価指標の詳細】
+
+- CMI Score: (Binary F1 + Macro F1) / 2.0
+- Binary F1: ターゲット vs 非ターゲットの2値分類F1スコア
+- Macro F1: 全ジェスチャーのマクロF1スコア（非ターゲットは統合）
+
+【ターゲットジェスチャー（8種類）】
+- Above ear - pull hair
+- Cheek - pinch skin
+- Eyebrow - pull hair
+- Eyelash - pull hair
+- Forehead - pull hairline
+- Forehead - scratch
+- Neck - pinch skin
+- Neck - scratch
+
+【非ターゲットジェスチャー（10種類）】
+- Write name on leg
+- Wave hello
+- Glasses on/off
+- Text on phone
+- Write name in air
+- Feel around in tray and pull out an object
+- Scratch knee/leg skin
+- Pull air toward your face
+- Drink from bottle/cup
+- Pinch knee/leg skin
+
+【関連スクリプト】
+
+学習履歴の可視化:
+python src/scripts/visualize_training_history.py --history path/to/training_history.json
+
+CMI評価指標の追加:
+python src/scripts/add_cmi_metrics_to_history.py --demo --output demo_history.json
+""") 

--- a/submissions/v40_128/src/utils/config_utils.py
+++ b/submissions/v40_128/src/utils/config_utils.py
@@ -1,0 +1,45 @@
+import yaml
+from pathlib import Path
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "config_v2.yaml"
+
+
+def load_config(config_path=None):
+    """Load configuration from specified path or default path.
+    
+    Args:
+        config_path: Path to config file. If None, uses default config.
+        
+    Returns:
+        dict: Configuration dictionary
+    """
+    path = Path(config_path) if config_path else DEFAULT_CONFIG_PATH
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def get_preprocessing_params(config_path=None):
+    """Return preprocessing-related hyperparameters from config.
+    
+    Args:
+        config_path: Path to config file. If None, uses default config.
+        
+    Returns:
+        dict: Preprocessing parameters
+    """
+    cfg = load_config(config_path)
+    return cfg.get("preprocessing", {})
+
+
+def get_cache_dir(cfg: dict | None = None, config_path=None) -> Path:
+    """Return cache directory Path from config.
+    
+    Args:
+        cfg: Configuration dictionary. If None, loads from config_path.
+        config_path: Path to config file. If None, uses default config.
+        
+    Returns:
+        Path: Cache directory path
+    """
+    cfg = cfg or load_config(config_path)
+    return Path(cfg.get("cache_dir", "cache"))

--- a/submissions/v40_128/src/utils/feature_engineering.py
+++ b/submissions/v40_128/src/utils/feature_engineering.py
@@ -1,0 +1,324 @@
+import numpy as np
+import pandas as pd
+import warnings
+from scipy.signal import find_peaks
+
+# ============================================================
+# A. 基本統計量 (mean / std / range / RMS / energy)
+# ============================================================
+### --- Block A Summary ---------------------------------------
+# dims: 56 | 推奨モデル: LightGBM_all / non
+# 広域量的特徴――窓全体の強度・分布を圧縮
+# ------------------------------------------------------------
+def compute_basic_statistics(X_windows: np.ndarray) -> np.ndarray:
+    """Compute Block F statistics per window."""
+    # 外れ値にロバストな統計量を使用
+    means  = np.nanmean(X_windows, axis=1)
+    stds   = np.nanstd(X_windows, axis=1)
+    
+    # パーセンタイルベースの範囲（外れ値にロバスト）
+    q25 = np.nanpercentile(X_windows, 25, axis=1)
+    q75 = np.nanpercentile(X_windows, 75, axis=1)
+    ranges = q75 - q25  # 四分位範囲（IQR）
+    
+    # 外れ値を除外したRMSとエネルギー
+    # 各ウィンドウで外れ値を除外してから計算
+    rms_values = []
+    energy_values = []
+    
+    for i in range(X_windows.shape[0]):
+        window_data = X_windows[i, :, :]
+        
+        # 外れ値を除外（各軸ごと）
+        clean_data = []
+        for axis in range(window_data.shape[1]):
+            axis_data = window_data[:, axis]
+            q1, q99 = np.nanpercentile(axis_data, [1, 99])
+            clean_axis = axis_data[(axis_data >= q1) & (axis_data <= q99)]
+            clean_data.append(clean_axis)
+        
+        # 全軸のデータを結合
+        all_clean_data = np.concatenate(clean_data)
+        
+        if len(all_clean_data) > 0:
+            rms = np.sqrt(np.nanmean(all_clean_data ** 2))
+            energy = np.nansum(all_clean_data ** 2)
+        else:
+            rms = 0.0
+            energy = 0.0
+            
+        rms_values.append(rms)
+        energy_values.append(energy)
+    
+    rms = np.array(rms_values)
+    energy = np.array(energy_values)
+    
+    if X_windows.shape[2] >= 3:
+        mag = np.linalg.norm(X_windows[:, :, :3], axis=2)
+        mag_mean = np.nanmean(mag, axis=1, keepdims=True)
+        mag_std  = np.nanstd(mag, axis=1, keepdims=True)
+        return np.hstack([means, stds, ranges, rms.reshape(-1, 1), energy.reshape(-1, 1), mag_mean, mag_std])
+    else:
+        return np.hstack([means, stds, ranges, rms.reshape(-1, 1), energy.reshape(-1, 1)])
+
+
+# ============================================================
+# B. ピーク & 周期特徴量
+# ============================================================
+### --- Block B Summary ---------------------------------------
+# dims: 18 | 推奨モデル: LightGBM_all / non
+# BFRB の “反復性” をカウントして数値化
+# ------------------------------------------------------------
+
+def extract_peak_features(window: np.ndarray) -> np.ndarray:
+    """Return per‑axis peak counts (Block D)."""
+    return np.array([len(find_peaks(window[:, i])[0]) for i in range(window.shape[1])], dtype=np.float32)
+
+
+def compute_peak_features(X_windows: np.ndarray) -> np.ndarray:
+    """Compute peak features per window."""
+    def extract_peak_features(window):
+        features = []
+        for axis in range(window.shape[1]):
+            signal = window[:, axis]
+            
+            # 外れ値を除外してからピーク検出
+            q1, q99 = np.nanpercentile(signal, [1, 99])
+            clean_signal = signal[(signal >= q1) & (signal <= q99)]
+            
+            if len(clean_signal) > 10:  # 十分なデータがある場合のみ
+                peaks, _ = find_peaks(clean_signal, height=np.nanmean(clean_signal))
+                n_peaks = len(peaks)
+                
+                if n_peaks > 0:
+                    peak_heights = clean_signal[peaks]
+                    avg_peak_height = np.nanmean(peak_heights)
+                    max_peak_height = np.nanmax(peak_heights)
+                    peak_ratio = n_peaks / len(clean_signal)
+                else:
+                    avg_peak_height = 0.0
+                    max_peak_height = 0.0
+                    peak_ratio = 0.0
+            else:
+                n_peaks = 0
+                avg_peak_height = 0.0
+                max_peak_height = 0.0
+                peak_ratio = 0.0
+            
+            features.extend([n_peaks, avg_peak_height, max_peak_height, peak_ratio])
+        return features
+    
+    return np.vstack([extract_peak_features(w) for w in X_windows])
+
+
+# ============================================================
+# C. FFT バンドエネルギー (0.5–20 Hz)
+# ============================================================
+### --- Block C Summary ---------------------------------------
+# dims: 10 | 推奨モデル: LightGBM_all / non
+# 動作リズム・速度の周波数分布
+# ------------------------------------------------------------
+
+def compute_fft_band_energy(X_windows: np.ndarray, fs: float = 50.0, bands=None) -> np.ndarray:
+    """Compute block G FFT band energies."""
+    if bands is None:
+        bands = [(0.5, 2), (2, 5), (5, 10), (10, 20)]
+    n_win, win_len, n_feat = X_windows.shape
+    freqs = np.fft.rfftfreq(win_len, d=1.0 / fs)
+    
+    energies = []
+    for lo, hi in bands:
+        mask = (freqs >= lo) & (freqs < hi)
+        band_energies = []
+        
+        for i in range(n_win):
+            window_energies = []
+            for j in range(n_feat):
+                signal = X_windows[i, :, j]
+                
+                # 外れ値を除外してからFFT計算
+                q1, q99 = np.nanpercentile(signal, [1, 99])
+                clean_signal = signal[(signal >= q1) & (signal <= q99)]
+                
+                if len(clean_signal) > 10:
+                    # パディングして元の長さに戻す
+                    padded_signal = np.zeros(win_len)
+                    padded_signal[:len(clean_signal)] = clean_signal
+                    
+                    power = np.abs(np.fft.rfft(padded_signal)) ** 2
+                    energy = power[mask].sum()
+                else:
+                    energy = 0.0
+                
+                window_energies.append(energy)
+            band_energies.append(window_energies)
+        
+        energies.append(np.array(band_energies))
+    
+    return np.hstack(energies)
+
+
+# ============================================================
+# E. 欠損フラグ (missing sensor flags)
+# ============================================================
+### --- Block E Summary ---------------------------------------
+# dims: 3 | 推奨モデル: すべて
+# 未接続センサを one-hot で明示
+# ------------------------------------------------------------
+def add_missing_sensor_flags(df: pd.DataFrame, sensor_groups: dict) -> pd.DataFrame:
+    """Add boolean missing‑sensor flags per group (Block E)."""
+    for flag, cols in sensor_groups.items():
+        df[flag] = df[cols].isna().all(axis=1)
+    return df
+
+# ============================================================
+# G. TDA Stats (Persistence Image)
+# ============================================================
+### --- Block G Summary ---------------------------------------
+# dims: 8 | 推奨モデル: CNN-GRU concat / LightGBM
+# 位相的周期性を独自にエンコード
+# ------------------------------------------------------------
+def compute_persistence_image_features(X_windows: np.ndarray, dimension:int=1, n_bins:int=20, sigma:float=0.1) -> np.ndarray:
+    """Block J: persistence image features via giotto‑tda."""
+    from gtda.time_series import TakensEmbedding
+    from gtda.homology import VietorisRipsPersistence
+    from gtda.diagrams import PersistenceImage
+
+    emb = TakensEmbedding(time_delay=1, dimension=dimension)
+    vrp = VietorisRipsPersistence(homology_dimensions=[0, 1])
+    pim = PersistenceImage(sigma=sigma, n_bins=n_bins)
+    feats = []
+    for w in X_windows:
+        e = emb.fit_transform(w)
+        d = vrp.fit_transform(e)
+        img = pim.fit_transform(d)
+        feats.append(img.reshape(-1))
+    return np.array(feats, dtype=np.float32)
+
+def compute_persistence_image_features_batch(
+    X_windows: np.ndarray, dimension: int = 2, n_bins: int = 16, sigma: float = 0.1
+) -> np.ndarray:
+    try:
+        from gtda.time_series import TakensEmbedding
+        from gtda.homology import VietorisRipsPersistence
+        from gtda.diagrams import PersistenceImage
+    except ImportError:
+        warnings.warn(
+            "giotto-tda がインストールされていないため、TDA特徴量をスキップします。"
+        )
+        return np.zeros((X_windows.shape[0], 0), dtype=np.float32)
+
+    # デバッグ: TDA処理前のNaN値確認
+    nan_count = np.isnan(X_windows).sum()
+    if nan_count > 0:
+        print(f"⚠️  TDA処理前: NaN値 {nan_count} 個を発見")
+        print(f"   データ形状: {X_windows.shape}")
+        
+        # NaN値を処理
+        X_windows_clean = np.nan_to_num(X_windows, nan=0.0, posinf=1.0, neginf=-1.0)
+        print(f"✅ NaN値を0.0に置換しました")
+    else:
+        X_windows_clean = X_windows
+        print(f"✅ TDA処理前: NaN値なし")
+
+    # 1. Takens埋め込み（全ウィンドウまとめて）
+    emb = TakensEmbedding(time_delay=1, dimension=dimension)
+    embedded = emb.fit_transform(X_windows_clean)  # shape: (n_samples, new_len, dimension)
+
+    # 2. パーシステンス図（全ウィンドウまとめて）
+    vrp = VietorisRipsPersistence(homology_dimensions=[0, 1])
+    diagrams = vrp.fit_transform(embedded)   # shape: (n_samples, n_points, 3)
+
+    # 3. パーシステンス画像（全ウィンドウまとめて）
+    pim = PersistenceImage(sigma=sigma, n_bins=n_bins)
+    images = pim.fit_transform(diagrams)     # shape: (n_samples, n_bins, n_bins)
+
+    # 4. ベクトル化
+    feats = images.reshape(images.shape[0], -1)
+    return feats.astype(np.float32)
+
+# ============================================================
+# H. Auto-Encoder 再構成誤差
+# ============================================================
+### --- Block H Summary ---------------------------------------
+# dims: 4 | 推奨モデル: LightGBM / Binary-GRU (aux)
+# 異常度スコアで BFRB 境界を補強
+# ------------------------------------------------------------
+
+def compute_autoencoder_reconstruction_error(X_windows: np.ndarray, model) -> np.ndarray:
+    """Block K: per‑window MSE reconstruction error from a trained AE."""
+    recon = model.predict(X_windows, verbose=0)
+    return ((X_windows - recon) ** 2).mean(axis=(1, 2), keepdims=True)
+
+
+
+# ============================================================
+# M. Wavelet 周波数特徴 (DWT energies)
+# ============================================================
+
+def compute_wavelet_features(X_windows: np.ndarray, wavelet: str = "db4", level: int = 3) -> np.ndarray:
+    """Block I: discrete wavelet band energies using PyWavelets."""
+    import pywt
+    
+    # NaN値処理
+    nan_count = np.isnan(X_windows).sum()
+    if nan_count > 0:
+        print(f"⚠️  Wavelet処理前: NaN値 {nan_count} 個を発見")
+        X_windows_clean = np.nan_to_num(X_windows, nan=0.0, posinf=1.0, neginf=-1.0)
+        print(f"✅ NaN値を0.0に置換しました")
+    else:
+        X_windows_clean = X_windows
+    
+    feats = []
+    for w in X_windows_clean:
+        ax_feats = []
+        for i in range(w.shape[1]):
+            coeffs = pywt.wavedec(w[:, i], wavelet=wavelet, level=level)
+            ax_feats += [np.sum(c ** 2) for c in coeffs]
+        feats.append(ax_feats)
+    return np.array(feats, dtype=np.float32)
+
+
+# ============================================================
+# N. ToF イベント特徴量
+# ============================================================
+
+def compute_tof_event_features(X_windows: np.ndarray) -> np.ndarray:
+    """Compute simple ToF event features.
+
+    各ウィンドウについて以下を計算します。
+
+    - 最小距離値
+    - 時系列方向の絶対変化率平均
+    """
+
+    window_min = X_windows.min(axis=(1, 2, 3, 4))[:, None]
+    diff = np.diff(X_windows, axis=1)
+    rate = np.mean(np.abs(diff), axis=(1, 2, 3, 4))[:, None]
+    return np.hstack([window_min, rate])
+
+
+# ============================================================
+# O. 温度勾配特徴量
+# ============================================================
+
+def compute_temperature_gradient_features(X_windows: np.ndarray) -> np.ndarray:
+    """Compute temperature gradient based features.
+
+    Parameters
+    ----------
+    X_windows : np.ndarray
+        Shape ``(N, T, C)`` where ``C`` is the数 of thermal sensors.
+
+    Returns
+    -------
+    np.ndarray
+        ``(N, C*3)`` array containing mean/std of first differences and
+        peak（max-min）for each channel.
+    """
+
+    diffs = np.diff(X_windows, axis=1)
+    diff_mean = diffs.mean(axis=1)
+    diff_std = diffs.std(axis=1)
+    peak_width = X_windows.max(axis=1) - X_windows.min(axis=1)
+    return np.hstack([diff_mean, diff_std, peak_width])

--- a/submissions/v40_128/src/utils/imu.py
+++ b/submissions/v40_128/src/utils/imu.py
@@ -1,0 +1,47 @@
+# --- utils/imu.py -------------------------------------------------------
+import numpy as np
+import pandas as pd
+from scipy.spatial.transform import Rotation as R
+
+GRAVITY = 9.80665   # [m/s²]
+
+def quat_normalize_safe(quat: np.ndarray) -> np.ndarray:
+    norm = np.linalg.norm(quat, axis=1, keepdims=True)
+    mask_zero = norm.squeeze() < 1e-6
+    quat[mask_zero] = np.array([1, 0, 0, 0])          # identity
+    quat[~mask_zero] /= norm[~mask_zero]
+    return quat
+
+def accel_world_linear(acc: np.ndarray, quat: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Parameters
+    ----------
+    acc  : (N,3) body-frame raw accelerometer
+    quat : (N,4) quaternion (w,x,y,z) body→world
+
+    Returns
+    -------
+    acc_w  : (N,3) world-frame acceleration
+    lin_acc: (N,3) world-frame linear acceleration (= acc_w – g)
+    """
+    quat = quat_normalize_safe(quat)
+    rot  = R.from_quat(quat[:, [1,2,3,0]])            # (x,y,z,w)
+    acc_w = rot.apply(acc)
+    lin   = acc_w - np.array([0, 0, GRAVITY])
+    return acc_w, lin
+
+def add_world_acc_features(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    前提: 欠損補間 & handedness_correction_v2 後の DataFrame
+    追加列:
+        acc_w_[xyz], lin_acc_[xyz]
+    """
+    df = df.copy()
+    acc  = df[['acc_x','acc_y','acc_z']].to_numpy(dtype=np.float32)
+    quat = quat_normalize_safe(                          # ← ここを変更
+        df[['rot_w','rot_x','rot_y','rot_z']].to_numpy(dtype=np.float32)
+    )
+    acc_w, lin = accel_world_linear(acc, quat)
+    df[['acc_w_x','acc_w_y','acc_w_z']]     = acc_w
+    df[['lin_acc_x','lin_acc_y','lin_acc_z']] = lin
+    return df

--- a/submissions/v40_128/src/utils/io_utils.py
+++ b/submissions/v40_128/src/utils/io_utils.py
@@ -1,0 +1,44 @@
+# src/utils/io_utils.py
+from pathlib import Path
+import pandas as pd, json, hashlib
+
+
+def df_md5(df: pd.DataFrame) -> str:
+    """DataFrame から MD5 ハッシュを計算する"""
+    data = pd.util.hash_pandas_object(df, index=True).values
+    return hashlib.md5(data.tobytes()).hexdigest()
+
+CACHE_DIR   = Path("cache")
+TRAIN_PARQ  = CACHE_DIR / "train_clean.parquet"
+TEST_PARQ   = CACHE_DIR / "test_clean.parquet"
+META_JSON   = CACHE_DIR / "clean_meta.json"
+
+def _md5(path: Path) -> str:
+    return hashlib.md5(path.read_bytes()).hexdigest()
+
+def load_clean_data(raw_train_csv="data/train.csv",
+                    raw_test_csv="data/test.csv",
+                    strict=True):
+    """
+    前処理済み Parquet を読み込む。
+    * strict=True なら MD5 がズレていた場合は例外を投げる
+    """
+    if not TRAIN_PARQ.exists() or not TEST_PARQ.exists():
+        raise FileNotFoundError("cleaned parquet not found – 先に前処理セルを実行してください")
+
+    # MD5 チェック
+    if META_JSON.exists():
+        meta = json.loads(META_JSON.read_text())
+        if strict:
+            if meta["raw_train_md5"] != _md5(Path(raw_train_csv)):
+                raise RuntimeError("raw train CSV has changed – recalc needed")
+            if meta["raw_test_md5"]  != _md5(Path(raw_test_csv)):
+                raise RuntimeError("raw test CSV has changed – recalc needed")
+    else:
+        print("⚠️ meta file not found – skipping MD5 check")
+
+    print("📥 loading cached parquet …", end="", flush=True)
+    train_df = pd.read_parquet(TRAIN_PARQ)
+    test_df  = pd.read_parquet(TEST_PARQ)
+    print("done")
+    return train_df, test_df

--- a/submissions/v40_128/src/utils/kaggle.py
+++ b/submissions/v40_128/src/utils/kaggle.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+
+def is_kaggle():
+    # Kaggle環境ではこの環境変数が必ず存在
+    return "KAGGLE_URL_BASE" in os.environ or Path("/kaggle").exists()
+
+if is_kaggle():
+    # Kaggle環境
+    PROJECT_ROOT = Path("/kaggle/input/cmi-ensemble-v20/")
+    DATA_DIR = Path("/kaggle/input/cmi-detect-behavior-with-sensor-data/")
+    EVAL_MODULE_DIR = Path("/kaggle/input/cmi-detect-behavior-with-sensor-data/")
+else:
+    # ローカル環境
+    PROJECT_ROOT = Path("/mnt/c/Users/ShunK/works/CMI_comp/submissions/ensemble_v1")
+    DATA_DIR = Path("../../data/")
+    EVAL_MODULE_DIR = Path("/mnt/c/Users/ShunK/works/CMI_comp/submissions/ensemble_v1/kaggle_evaluation")
+
+# # 例：使い方
+# print("PROJECT_ROOT:", PROJECT_ROOT)
+# print("DATA_DIR:", DATA_DIR)
+# print("EVAL_MODULE_DIR:", EVAL_MODULE_DIR)

--- a/submissions/v40_128/src/utils/pipeline.py
+++ b/submissions/v40_128/src/utils/pipeline.py
@@ -1,0 +1,897 @@
+# -*- coding: utf-8 -*-
+"""Preprocessing pipeline utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import json
+import pickle
+import logging
+from sklearn.preprocessing import StandardScaler
+
+from .io_utils import df_md5
+
+from pathlib import Path
+import yaml
+
+from .preprocessing import (
+    create_sliding_windows_with_demographics,
+    create_tof_windows_with_info,
+    handedness_correction_v2,
+    augment_handedness_flip,
+    clean_sensor_missing_values,
+    clean_missing_sensor_data_parallel_disk,
+)
+from .feature_engineering import add_missing_sensor_flags
+from .config_utils import load_config, get_cache_dir
+from .tof import tof_to_voxel_tensor
+from .feature_engineering import (
+    compute_basic_statistics,
+    compute_peak_features,
+    compute_fft_band_energy,
+    compute_wavelet_features,
+    compute_persistence_image_features_batch,
+    compute_autoencoder_reconstruction_error,
+    compute_tof_event_features,
+    compute_temperature_gradient_features,
+)
+from .imu import add_world_acc_features
+
+
+logger = logging.getLogger(__name__)
+
+class WindowTensorBuilder:
+    """Generate IMU window tensors with demographics."""
+
+    # def __init__(self, config: dict | None = None) -> None:
+    def __init__(self, config: dict | None = None, mode: str = "train") -> None:
+        self.config = config or load_config()
+        self.mode = mode
+        pp = self.config.get("preprocessing", {})
+        self.window_size = pp.get("window_size", 128)
+        self.stride = pp.get("stride", 64)
+        self.min_len = pp.get("min_sequence_length", 10)
+        self.padding_value = pp.get("padding_value", 0.0)
+        
+        self.sensor_cols = (
+            self.config.get("sensor_acc_cols", [])
+            + self.config.get("sensor_rot_cols", [])
+            + self.config.get("sensor_thm_cols", [])
+        )
+        if pp.get("use_world_acc", False):
+            world_acc_cols = [f"acc_w_{ax}" for ax in "xyz"] + [f"lin_acc_{ax}" for ax in "xyz"]
+            self.sensor_cols.extend(world_acc_cols)
+        
+        self.demographics_cols = self.config.get("demographics_cols", [])
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "windows.pkl"
+        self.meta_file = self.cache_dir / "windows_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(self, df: pd.DataFrame, use_cache: bool = True):
+        logger.info(
+            "Building windows (size=%d, stride=%d, min_len=%d)",
+            self.window_size,
+            self.stride,
+            self.min_len,
+        )
+        md5 = df_md5(df)
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached windows from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        result = create_sliding_windows_with_demographics(
+            df,
+            window_size=self.window_size,
+            stride=self.stride,
+            sensor_cols=self.sensor_cols,
+            demographics_cols=self.demographics_cols,
+            min_sequence_length=self.min_len,
+            padding_value=self.padding_value,
+        )
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info(
+            "Windows shapes: X_sensor=%s, X_demo=%s, y=%s",
+            result[0].shape,
+            result[1].shape,
+            result[2].shape,
+        )
+        return result
+
+
+class TabularFeatureBuilder:
+    """Build tabular features from IMU windows."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        self.sampling_rate = pp.get("sampling_rate", 50.0)
+        self.fft_bands = pp.get("fft_bands", [])
+        self.use_wavelet = pp.get("use_wavelet_features", False)
+        self.use_tda = pp.get("use_tda_features", False)
+        self.use_tof_event = pp.get("use_tof_event_features", False)
+        self.use_temp_grad = pp.get("use_temperature_gradient_features", False)
+        self.wavelet = pp.get("wavelet", "db4")
+        self.wavelet_level = pp.get("wavelet_level", 3)
+        self.tda_dimension = pp.get("tda_dimension", 1)
+        self.tda_bins = pp.get("tda_bins", 20)
+        self.tda_sigma = pp.get("tda_sigma", 0.1)
+        self.window_builder = WindowTensorBuilder(self.config)
+        self.tof_win_builder = ToFWindowBuilder(self.config)
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tabular_features.pkl"
+        self.meta_file = self.cache_dir / "tabular_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(
+        self,
+        df: pd.DataFrame,
+        windows=None,
+        use_cache: bool = True,
+        *,
+        use_wavelet: bool | None = None,
+        use_tda: bool | None = None,
+        use_tof_event: bool | None = None,
+        use_temp_grad: bool | None = None,
+        autoencoder_model=None,
+    ):
+        """Return tabular features for each window.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        windows : tuple or None
+            Precomputed window tensors from :class:`WindowTensorBuilder`.
+        use_cache : bool, default True
+            If True, reuse cached results when available.
+        use_wavelet : bool | None, optional
+            Override config to compute wavelet features.
+        use_tda : bool | None, optional
+            Override config to compute TDA features.
+        use_tof_event : bool | None, optional
+            Override config to compute ToF event features.
+        use_temp_grad : bool | None, optional
+            Override config to compute temperature gradient features.
+        autoencoder_model : optional
+            Pre-trained model used to compute reconstruction errors. The
+            object must implement ``predict`` and return reconstructed
+            windows with the same shape as the input.
+        """
+
+        md5 = df_md5(df)
+        use_wavelet = self.use_wavelet if use_wavelet is None else use_wavelet
+        use_tda = self.use_tda if use_tda is None else use_tda
+        use_tof_event = self.use_tof_event if use_tof_event is None else use_tof_event
+        use_temp_grad = self.use_temp_grad if use_temp_grad is None else use_temp_grad
+        logger.info(
+            "Building tabular features (wavelet=%s, tda=%s, tof_event=%s, temp_grad=%s)",
+            use_wavelet,
+            use_tda,
+            use_tof_event,
+            use_temp_grad,
+        )
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached tabular features from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        if windows is None:
+            X_sensor, X_demo, y, info = self.window_builder.build(df, use_cache=use_cache)
+        else:
+            X_sensor, X_demo, y, info = windows
+            
+        # 外れ値処理はPreprocessorで行うため、ここでは不要
+        X_sensor_clean = X_sensor
+        
+        stats = compute_basic_statistics(X_sensor_clean)
+        peaks = compute_peak_features(X_sensor_clean)
+        fft = compute_fft_band_energy(
+            X_sensor_clean, fs=self.sampling_rate, bands=self.fft_bands
+        )
+
+        # decide whether to compute optional features
+        feats = [stats, peaks, fft]
+        if use_wavelet:
+            wave = compute_wavelet_features(
+                X_sensor_clean, wavelet=self.wavelet, level=self.wavelet_level
+            )
+            feats.append(wave)
+        if use_tda:
+            tda = compute_persistence_image_features_batch(
+                X_sensor_clean,
+                dimension=self.tda_dimension,
+                n_bins=self.tda_bins,
+                sigma=self.tda_sigma,
+            )
+            feats.append(tda)
+        if use_tof_event:
+            X_tof, _ = self.tof_win_builder.build(df, use_cache=use_cache)
+            tof_feat = compute_tof_event_features(X_tof)
+            feats.append(tof_feat)
+        if use_temp_grad:
+            thm_cols = self.config.get("sensor_thm_cols", [])
+            if thm_cols:
+                sensor_config = self.window_builder.sensor_cols
+                idx = [sensor_config.index(c) for c in thm_cols if c in sensor_config]
+                if idx:
+                    temp_feat = compute_temperature_gradient_features(
+                        X_sensor_clean[:, :, idx]
+                    )
+                    feats.append(temp_feat)
+        if autoencoder_model is not None:
+            ae_err = compute_autoencoder_reconstruction_error(
+                X_sensor_clean, autoencoder_model
+            ).reshape(len(X_sensor_clean), -1)
+            feats.append(ae_err)
+            
+        # --- 欠損センサフラグ (per-window mean) ----------------------
+        flag_cols = [
+            c
+            for c in [
+                "missing_flag_imu",
+                "missing_flag_thermal",
+                "missing_flag_tof",
+            ]
+            if c in df.columns
+        ]
+        if flag_cols:
+            grouped = {
+                (s, sid): g[flag_cols].to_numpy(float)
+                for (s, sid), g in df.groupby(["subject", "sequence_id"])
+            }
+            flags = []
+            for m in info:
+                arr = grouped[(m["subject"], m["sequence_id"])]
+                start = m["start_idx"]
+                end = min(m["end_idx"], arr.shape[0])
+                flags.append(arr[start:end].mean(axis=0))
+            flag_array = np.vstack(flags)
+            if flag_array.any():
+                feats.append(flag_array)
+
+        # 最終的なNaN値チェック
+        features = np.hstack(feats + [X_demo])
+        final_nan_count = np.isnan(features).sum()
+        if final_nan_count > 0:
+            logger.warning(f"TabularFeatureBuilder: 最終特徴量にNaN値 {final_nan_count} 個を検出、0.0に置換")
+            features = np.nan_to_num(features, nan=0.0, posinf=1.0, neginf=-1.0)
+        result = (features, y, info)
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info("Tabular features shape %s", result[0].shape)
+        return result
+
+
+class ToFVoxelBuilder:
+    """Convert ToF pixel columns to voxel tensor."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        self.fill_value = pp.get("padding_value", 0.0)
+        depth = pp.get("tof_depth", 5)
+        h = pp.get("tof_height", 8)
+        w = pp.get("tof_width", 8)
+        self.tof_cols = [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)]
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tof_voxel.pkl"
+        self.meta_file = self.cache_dir / "tof_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(self, df: pd.DataFrame, use_cache: bool = True):
+        logger.info("Building ToF voxel tensor")
+        md5 = df_md5(df)
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached ToF voxel from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        sub = df[self.tof_cols] if all(c in df.columns for c in self.tof_cols) else df
+        result = tof_to_voxel_tensor(sub, fill_value=self.fill_value)
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info("ToF voxel shape %s", result.shape)
+        return result
+
+
+class ToFWindowBuilder:
+    """Create sliding windows from ToF voxel tensor."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        self.window_size = pp.get("window_size", 128)
+        self.stride = pp.get("stride", 64)
+        self.min_len = pp.get("min_sequence_length", 10)
+        self.fill_value = pp.get("padding_value", 0.0)
+        depth = pp.get("tof_depth", 5)
+        h = pp.get("tof_height", 8)
+        w = pp.get("tof_width", 8)
+        self.tof_cols = [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)]
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tof_windows.pkl"
+        self.meta_file = self.cache_dir / "tof_windows_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(self, df: pd.DataFrame, use_cache: bool = True):
+        logger.info(
+            "Building ToF windows (size=%d, stride=%d, min_len=%d)",
+            self.window_size,
+            self.stride,
+            self.min_len,
+        )
+        md5 = df_md5(df)
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached ToF windows from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        result = create_tof_windows_with_info(
+            df,
+            window_size=self.window_size,
+            stride=self.stride,
+            tof_cols=self.tof_cols,
+            min_sequence_length=self.min_len,
+            fill_value=self.fill_value,
+        )
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info("ToF windows shape %s", result[0].shape)
+        return result
+
+
+class Preprocessor:
+    """Manage preprocessing statistics and transformations."""
+
+    def __init__(
+        self,
+        config: dict | None = None,
+        *,
+        use_handedness: bool = True,
+        use_basic_cleaning: bool = True,
+        use_interp_cleaning: bool = True,
+        use_world_acc: bool | None = None,
+    ) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        if use_world_acc is None:
+            use_world_acc = pp.get("use_world_acc", False)
+        self.use_handedness_augmentation = pp.get("use_handedness_augmentation", False)
+        self.win_builder = WindowTensorBuilder(self.config)
+        self.tab_builder = TabularFeatureBuilder(self.config)
+        self.tof_builder = ToFVoxelBuilder(self.config)
+        self.tof_win_builder = ToFWindowBuilder(self.config)
+
+        self.sensor_scaler = StandardScaler()
+        self.demo_scaler = StandardScaler()
+        self.tab_scaler = StandardScaler()
+
+        self.use_handedness = use_handedness
+        self.use_basic_cleaning = use_basic_cleaning
+        self.use_interp_cleaning = use_interp_cleaning
+        self.use_world_acc = use_world_acc
+        # handedness augmentation option
+        self.use_handedness_augmentation = bool(self.use_handedness_augmentation)
+
+        pp = self.config.get("preprocessing", {})
+        depth = pp.get("tof_depth", 5)
+        h = pp.get("tof_height", 8)
+        w = pp.get("tof_width", 8)
+        self.sensor_type_groups = {
+            "Accelerometer": list(self.config.get("sensor_acc_cols", [])),
+            "World_Accelerometer": [],  # ワールド座標系専用
+            "Rotation": self.config.get("sensor_rot_cols", []),
+            "Thermal": self.config.get("sensor_thm_cols", []),
+            "ToF_Sensor": [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)],
+        }
+        if self.use_world_acc:
+            self.sensor_type_groups["World_Accelerometer"].extend(
+                [f"acc_w_{ax}" for ax in "xyz"]
+                + [f"lin_acc_{ax}" for ax in "xyz"]
+            )
+
+        interp_path = Path(__file__).resolve().parents[2] / "config" / "interp_params.yaml"
+        if interp_path.exists():
+            with open(interp_path, "r") as f:
+                self.interp_params = yaml.safe_load(f)
+        else:
+            self.interp_params = None
+
+        self._fitted = False
+
+    def _maybe_clean(self, df: pd.DataFrame) -> pd.DataFrame:
+        processed = df.copy()
+        if self.use_handedness:
+            processed = handedness_correction_v2(processed)
+        if self.use_basic_cleaning:
+            processed = clean_sensor_missing_values(
+                processed, self.sensor_type_groups
+            )
+        # 欠損センサフラグを付与
+        flag_groups = {
+            "missing_flag_imu": self.sensor_type_groups.get("Accelerometer", [])
+            + self.sensor_type_groups.get("Rotation", []),
+            "missing_flag_thermal": self.sensor_type_groups.get("Thermal", []),
+            "missing_flag_tof": self.sensor_type_groups.get("ToF_Sensor", []),
+        }
+        processed = add_missing_sensor_flags(processed, flag_groups)
+
+        if self.use_interp_cleaning:
+            base_keep = self.config.get("demographics_cols", [])
+            # Only include columns that exist in the dataframe
+            keep = [col for col in base_keep + ["gesture"] if col in df.columns]
+            keep.extend(flag_groups.keys())
+            processed = clean_missing_sensor_data_parallel_disk(
+                processed,
+                sensor_type_groups=self.sensor_type_groups,
+                interp_params=self.interp_params,
+                keep_cols=keep,
+            )
+        if self.use_world_acc:
+            processed = add_world_acc_features(processed)
+        return processed
+    
+    def _debug_nan_values(self, X_sensor: np.ndarray, stage: str = ""):
+        """NaN値のデバッグ用関数"""
+        if X_sensor is None:
+            return
+            
+        nan_count = np.isnan(X_sensor).sum()
+        if nan_count > 0:
+            print(f"⚠️  {stage}: NaN値 {nan_count} 個を発見")
+            
+            # どの次元にNaNがあるかを確認
+            nan_mask = np.isnan(X_sensor)
+            if nan_mask.any():
+                # ウィンドウごとのNaN数
+                nan_per_window = nan_mask.sum(axis=(1, 2))
+                windows_with_nan = (nan_per_window > 0).sum()
+                print(f"   NaNを含むウィンドウ数: {windows_with_nan}/{len(X_sensor)}")
+                
+                # 特徴量次元ごとのNaN数
+                nan_per_feature = nan_mask.sum(axis=(0, 1))
+                features_with_nan = (nan_per_feature > 0).sum()
+                print(f"   NaNを含む特徴量数: {features_with_nan}/{X_sensor.shape[-1]}")
+                
+                # 各特徴量のNaN数を詳細表示
+                sensor_config = self.win_builder.sensor_cols
+                print("   各特徴量のNaN数:")
+                for i, count in enumerate(nan_per_feature):
+                    if count > 0:
+                        col_name = sensor_config[i] if i < len(sensor_config) else f"feature_{i}"
+                        print(f"     {col_name} (index {i}): {count} 個")
+                
+                # 最初のNaNの位置を表示
+                nan_indices = np.where(nan_mask)
+                if len(nan_indices[0]) > 0:
+                    first_nan = (nan_indices[0][0], nan_indices[1][0], nan_indices[2][0])
+                    col_name = sensor_config[first_nan[2]] if first_nan[2] < len(sensor_config) else f"feature_{first_nan[2]}"
+                    print(f"   最初のNaN位置: ウィンドウ{first_nan[0]}, 時間{first_nan[1]}, {col_name}(index {first_nan[2]})")
+        else:
+            print(f"✅ {stage}: NaN値なし")
+            
+    def _handle_missing_values_by_sensor_type(self, X_sensor: np.ndarray) -> np.ndarray:
+        """センサー別に適切な欠損値処理を行う"""
+        if X_sensor is None:
+            return X_sensor
+            
+        X_clean = X_sensor.copy()
+        # # デバッグ: 処理前のNaN値確認
+        # self._debug_nan_values(X_sensor, "処理前")
+        
+        # センサー別の処理
+        sensor_config = self.win_builder.sensor_cols
+        acc_cols = self.config.get("sensor_acc_cols", [])
+        rot_cols = self.config.get("sensor_rot_cols", [])
+        thm_cols = self.config.get("sensor_thm_cols", [])
+
+        # ワールド座標系加速度の列を追加
+        world_acc_cols = []
+        if self.use_world_acc:
+            # ワールド座標系加速度の列を追加
+            world_acc_cols = self.sensor_type_groups.get("World_Accelerometer", [])
+            
+        acc_indices = []
+        rot_indices = []
+        thm_indices = []
+        world_acc_indices = []
+        
+        # Accelerometer: 0で置換（物理的に正当）
+        if acc_cols:
+            acc_indices = [sensor_config.index(col) for col in acc_cols if col in sensor_config]
+            for idx in acc_indices:
+                if idx < X_clean.shape[-1]:
+                    X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=0.0)
+        
+        # World Accelerometer: 0で置換（加速度と同様）
+        if world_acc_cols:
+            world_acc_indices = [sensor_config.index(col) for col in world_acc_cols if col in sensor_config]
+            for idx in world_acc_indices:
+                if idx < X_clean.shape[-1]:
+                    X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=0.0)
+    
+        # Rotation: 単位クォータニオンで置換
+        if rot_cols:
+            rot_indices = [sensor_config.index(col) for col in rot_cols if col in sensor_config]
+            for i, idx in enumerate(rot_indices):
+                if idx < X_clean.shape[-1]:
+                    if i == 0:  # w成分
+                        X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=1.0)
+                    else:  # x, y, z成分
+                        X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=0.0)
+        
+        # Thermal: 前後の値で補間（簡易版）
+        if thm_cols:
+            thm_indices = [sensor_config.index(col) for col in thm_cols if col in sensor_config]
+            for idx in thm_indices:
+                if idx < X_clean.shape[-1]:
+                    # 時系列方向で補間
+                    for window_idx in range(X_clean.shape[0]):
+                        series = X_clean[window_idx, :, idx]
+                        if np.isnan(series).any():
+                            # 前後の値で補間（空のスライス対策）
+                            if np.isnan(series).all():
+                                # すべてNaNの場合は0で置換
+                                series_clean = np.zeros_like(series)
+                            else:
+                                # 一部NaNの場合は平均で補間
+                                series_clean = np.nan_to_num(series, nan=np.nanmean(series))
+                            X_clean[window_idx, :, idx] = series_clean
+        
+        # その他のセンサー: 0で置換
+        all_processed_indices = set(acc_indices + rot_indices + thm_indices + world_acc_indices)
+        for i in range(X_clean.shape[-1]):
+            if i not in all_processed_indices:
+                X_clean[..., i] = np.nan_to_num(X_clean[..., i], nan=0.0)
+        
+        # # デバッグ: 処理後のNaN値確認
+        # self._debug_nan_values(X_clean, "処理後")
+        return X_clean
+
+    def _handle_outliers_in_sensor_data(self, X_sensor: np.ndarray, percentile_low: float = 0.5, percentile_high: float = 99.5) -> np.ndarray:
+        """センサーデータの外れ値を処理する
+        
+        Parameters
+        ----------
+        X_sensor : np.ndarray
+            センサーデータ
+        percentile_low : float, default 0.5
+            下位パーセンタイル（より厳しい外れ値検出）
+        percentile_high : float, default 99.5
+            上位パーセンタイル（より厳しい外れ値検出）
+        """
+        if X_sensor is None:
+            return X_sensor
+            
+        X_clean = X_sensor.copy()
+        
+        # 各センサー軸ごとに外れ値を処理
+        for axis in range(X_clean.shape[2]):
+            axis_data = X_clean[:, :, axis]
+            
+            # パーセンタイルベースのクリッピング（ウィンザライゼーション）
+            q_low = np.percentile(axis_data, percentile_low)
+            q_high = np.percentile(axis_data, percentile_high)
+            
+            # 外れ値をクリップ
+            axis_data_clipped = np.clip(axis_data, q_low, q_high)
+            X_clean[:, :, axis] = axis_data_clipped
+            
+            # ログ出力（最初の数軸のみ）
+            if axis < 3:
+                outlier_count = np.sum((axis_data < q_low) | (axis_data > q_high))
+                outlier_ratio = outlier_count / axis_data.size * 100
+                if outlier_ratio > 0.1:  # 0.1%以上の場合のみログ
+                    logger.info(f"軸{axis}: 外れ値{outlier_count:,}個 ({outlier_ratio:.2f}%) をクリップ ({percentile_low}%～{percentile_high}%)")
+        
+        return X_clean
+
+    def fit(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> "Preprocessor":
+        """Fit scalers using the provided dataframe.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        use_cache : bool, default True
+            Reuse cached results when available.
+        autoencoder_model : optional
+            Pre-trained model for reconstruction error features. It must
+            implement ``predict`` and return reconstructed windows.
+
+        Returns
+        -------
+        Preprocessor
+            The fitted instance.
+        """
+        logger.info("Fitting Preprocessor")
+        df_proc = self._maybe_clean(df)
+        if self.use_handedness_augmentation:
+            df_proc = augment_handedness_flip(df_proc)
+        windows = self.win_builder.build(df_proc, use_cache=use_cache)
+        X_sensor, X_demo, y, _ = windows
+        
+        # ラベルエンコーディング
+        if "gesture" in df.columns:
+            from sklearn.preprocessing import LabelEncoder
+            self.label_encoder = LabelEncoder()
+            self.label_encoder.fit(df["gesture"])
+            logger.info(f"ラベルエンコーダー作成: {self.label_encoder.classes_}")
+            logger.info(f"ラベルマッピング: {dict(zip(self.label_encoder.classes_, range(len(self.label_encoder.classes_))))}")
+        
+        # センサー別の適切な欠損値処理と外れ値処理
+        X_sensor_clean = self._handle_missing_values_by_sensor_type(X_sensor)
+        X_sensor_clean = self._handle_outliers_in_sensor_data(X_sensor_clean)
+        logger.info("Window tensor shape %s", X_sensor_clean.shape)
+        self.sensor_scaler.fit(X_sensor_clean.reshape(-1, X_sensor_clean.shape[-1]))
+    
+        
+        # 人口統計データの正規化
+        X_demo_clean = np.nan_to_num(X_demo, nan=0.0)
+        self.demo_scaler.fit(X_demo_clean)
+        
+        # 表形式特徴量の正規化
+        processed_windows = (X_sensor_clean, X_demo, y, windows[3])
+        tab, _, _ = self.tab_builder.build(
+            df_proc,
+            windows=processed_windows,
+            use_cache=use_cache,
+            autoencoder_model=autoencoder_model,
+        )
+        # --- クリップ処理を追加 ---
+        tab_clean = np.nan_to_num(tab, nan=0.0)
+        # クリップ閾値をfit時に保存
+        self.tab_clip_low = np.percentile(tab_clean, 0.5, axis=0)
+        self.tab_clip_high = np.percentile(tab_clean, 99.5, axis=0)
+        tab_clean = np.clip(tab_clean, self.tab_clip_low, self.tab_clip_high)
+        self.tab_scaler.fit(tab_clean)
+        logger.info("Tabular features shape %s", tab.shape)
+        
+        # === ToF正規化パラメータ計算 ===
+        tof_tensor = self.tof_builder.build(df_proc, use_cache=use_cache)
+        # 負の値を欠損値として扱う（-1だけでなく、負の値全体）
+        mask = (tof_tensor > 0)
+        if mask.sum() > 0:
+            self.tof_mean = float(tof_tensor[mask].mean())
+            self.tof_std = float(tof_tensor[mask].std())
+            logger.info(f"ToF mean: {self.tof_mean:.3f}, std: {self.tof_std:.3f} (有効値: {mask.sum():,}個)")
+        else:
+            self.tof_mean = 0.0
+            self.tof_std = 1.0
+            logger.warning("ToF: 有効な正の値が見つかりませんでした")
+
+        # ToF Windowsの正規化パラメータも計算
+        tof_windows_fit, _ = self.tof_win_builder.build(df_proc, use_cache=use_cache)
+        mask_win_fit = (tof_windows_fit > 0)
+        if mask_win_fit.sum() > 0:
+            self.tof_windows_mean = float(tof_windows_fit[mask_win_fit].mean())
+            self.tof_windows_std = float(tof_windows_fit[mask_win_fit].std())
+            logger.info(f"ToF Windows mean: {self.tof_windows_mean:.3f}, std: {self.tof_windows_std:.3f} (有効値: {mask_win_fit.sum():,}個)")
+        else:
+            self.tof_windows_mean = 0.0
+            self.tof_windows_std = 1.0
+            logger.warning("ToF Windows: 有効な正の値が見つかりませんでした")
+
+        self._fitted = True
+        return self
+
+    def transform(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> dict:
+        """Transform dataframe using fitted scalers.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        use_cache : bool, default True
+            Reuse cached results when available.
+        autoencoder_model : optional
+            Pre-trained model used for reconstruction error features. The
+            object must provide ``predict`` returning reconstructed windows.
+
+        Returns
+        -------
+        dict
+            Dictionary containing processed arrays.
+        """
+        if not self._fitted:
+            raise RuntimeError("Preprocessor is not fitted")
+        logger.info("Transforming dataframe of shape %s", df.shape)
+        df_proc = self._maybe_clean(df)
+        if self.use_handedness_augmentation:
+            df_proc = augment_handedness_flip(df_proc)
+        windows = self.win_builder.build(df_proc, use_cache=use_cache)
+        X_sensor, X_demo, y, info = windows
+        
+        # センサー別の適切な欠損値処理、外れ値処理、正規化
+        logger.info("Window tensor shape %s", X_sensor.shape)
+        X_sensor_clean = self._handle_missing_values_by_sensor_type(X_sensor)
+        X_sensor_clean = self._handle_outliers_in_sensor_data(X_sensor_clean)
+        X_sensor_normalized = self.sensor_scaler.transform(
+            X_sensor_clean.reshape(-1, X_sensor_clean.shape[-1])
+        ).reshape(X_sensor_clean.shape)
+        
+        # 人口統計データの正規化
+        X_demo_clean = np.nan_to_num(X_demo, nan=0.0)
+        X_demo_normalized = self.demo_scaler.transform(X_demo_clean)
+        
+        # 表形式特徴量の正規化
+        processed_windows = (X_sensor_clean, X_demo, y, info)
+        tab, _, _ = self.tab_builder.build(
+            df_proc,
+            windows=processed_windows,
+            use_cache=use_cache,
+            autoencoder_model=autoencoder_model,
+        )
+        # 欠損値処理と外れ値処理を追加してfit時とtransform時で一貫性を保つ
+        tab_clean = np.nan_to_num(tab, nan=0.0)
+        # --- クリップ処理をfitで保存した閾値で適用 ---
+        if hasattr(self, "tab_clip_low") and hasattr(self, "tab_clip_high"):
+            tab_clean = np.clip(tab_clean, self.tab_clip_low, self.tab_clip_high)
+        tab_normalized = self.tab_scaler.transform(tab_clean)
+        
+        # === ToF正規化 ===
+        tof_tensor = self.tof_builder.build(df_proc, use_cache=use_cache)
+        # 負の値を欠損値として扱う（-1だけでなく、負の値全体）
+        mask = (tof_tensor > 0)
+        tof_tensor_norm = np.zeros_like(tof_tensor)
+        if hasattr(self, "tof_mean") and hasattr(self, "tof_std") and self.tof_std > 0:
+            tof_tensor_norm[mask] = (tof_tensor[mask] - self.tof_mean) / self.tof_std
+            tof_tensor_norm[~mask] = -1  # 欠損値を-1で埋め戻す
+            logger.info(f"ToF正規化完了: 有効値{mask.sum():,}個, 欠損値{(~mask).sum():,}個")
+        else:
+            tof_tensor_norm = tof_tensor  # 正規化できない場合はそのまま
+            logger.warning("ToF: 正規化パラメータが利用できません")
+            
+        tof_windows, _ = self.tof_win_builder.build(df_proc, use_cache=use_cache)
+        mask_win = (tof_windows > 0)
+        tof_windows_norm = np.zeros_like(tof_windows)
+        if hasattr(self, "tof_windows_mean") and hasattr(self, "tof_windows_std") and self.tof_windows_std > 0:
+            tof_windows_norm[mask_win] = (tof_windows[mask_win] - self.tof_windows_mean) / self.tof_windows_std
+            tof_windows_norm[~mask_win] = -1  # 欠損値を-1で埋め戻す
+            logger.info(f"ToF Windows正規化完了: 有効値{mask_win.sum():,}個, 欠損値{(~mask_win).sum():,}個")
+        else:
+            tof_windows_norm = tof_windows
+            logger.warning("ToF Windows: 正規化パラメータが利用できません")
+            
+        logger.info(
+            "Output shapes: windows=%s, demographics=%s, tabular=%s, tof=%s, tof_win=%s",
+            X_sensor.shape,
+            X_demo.shape,
+            tab.shape,
+            tof_tensor.shape,
+            tof_windows.shape,
+        )
+        # ラベルエンコーディングの適用
+        if hasattr(self, "label_encoder") and y is not None:
+            # testデータかどうかを判定（-1のみの場合はtestデータ）
+            if len(np.unique(y)) == 1 and y[0] == -1:
+                logger.info("testデータのため、ラベルエンコーディングをスキップ")
+                y_encoded = y  # -1のまま保持
+            else:
+                # trainデータの場合のみラベルエンコーディングを適用
+                y_encoded = self.label_encoder.transform(y)
+                logger.info(f"ラベルエンコーディング適用: {np.unique(y_encoded)}")
+        else:
+            y_encoded = y
+        
+        return {
+            "windows": X_sensor_normalized,
+            "demographics": X_demo_normalized,
+            "tabular": tab_normalized,
+            "tof_voxel": tof_tensor_norm,  # 正規化済みデータを使用
+            "tof_windows": tof_windows_norm,  # 正規化済みデータを使用
+            "labels": y_encoded,
+            "info": info,
+        }
+
+    def fit_transform(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> dict:
+        self.fit(df, use_cache=use_cache, autoencoder_model=autoencoder_model)
+        return self.transform(
+            df, use_cache=use_cache, autoencoder_model=autoencoder_model
+        )
+        """Fit the preprocessor and transform the data in one call.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        use_cache : bool, default True
+            Reuse cached results when available.
+        autoencoder_model : optional
+            Pre-trained model with ``predict`` returning reconstructed
+            windows.
+
+        Returns
+        -------
+        dict
+            Dictionary of processed arrays.
+        """
+
+        self.fit(df, use_cache=use_cache, autoencoder_model=autoencoder_model)
+        return self.transform(df, use_cache=use_cache, autoencoder_model=autoencoder_model)
+
+    def save(self, path: Path) -> None:
+        """Save scaler objects and settings to a pickle file."""
+        logger.info("Saving Preprocessor to %s", path)
+        data = {
+            "config": self.config,
+            "use_handedness": self.use_handedness,
+            "use_basic_cleaning": self.use_basic_cleaning,
+            "use_interp_cleaning": self.use_interp_cleaning,
+            "use_world_acc": self.use_world_acc,
+            "use_handedness_augmentation": self.use_handedness_augmentation,
+            "sensor_scaler": self.sensor_scaler,
+            "demo_scaler": self.demo_scaler,
+            "tab_scaler": self.tab_scaler,
+            "_fitted": self._fitted,
+            "tof_mean": getattr(self, "tof_mean", None),
+            "tof_std": getattr(self, "tof_std", None),
+            "tof_windows_mean": getattr(self, "tof_windows_mean", None),
+            "tof_windows_std": getattr(self, "tof_windows_std", None),
+            "label_encoder": getattr(self, "label_encoder", None),
+        }
+        with open(path, "wb") as f:
+            pickle.dump(data, f)
+
+    @classmethod
+    def load(cls, path: Path) -> "Preprocessor":
+        """Load scalers and settings from a pickle file."""
+        logger.info("Loading Preprocessor from %s", path)
+        with open(path, "rb") as f:
+            data = pickle.load(f)
+        obj = cls(
+            data.get("config"),
+            use_handedness=data.get("use_handedness", True),
+            use_basic_cleaning=data.get("use_basic_cleaning", True),
+            use_interp_cleaning=data.get("use_interp_cleaning", True),
+            use_world_acc=data.get("use_world_acc"),
+        )
+        obj.sensor_scaler = data["sensor_scaler"]
+        obj.demo_scaler = data["demo_scaler"]
+        obj.tab_scaler = data["tab_scaler"]
+        obj._fitted = data.get("_fitted", False)
+        obj.tof_mean = data.get("tof_mean", None)
+        obj.tof_std = data.get("tof_std", None)
+        obj.tof_windows_mean = data.get("tof_windows_mean", None)
+        obj.tof_windows_std = data.get("tof_windows_std", None)
+        obj.label_encoder = data.get("label_encoder", None)
+        obj.use_handedness_augmentation = data.get("use_handedness_augmentation", False)
+        return obj

--- a/submissions/v40_128/src/utils/preprocessing.py
+++ b/submissions/v40_128/src/utils/preprocessing.py
@@ -1,0 +1,476 @@
+"""
+Preprocessing utilities for the CMI competition (commented version).
+
+"""
+
+import numpy as np
+import pandas as pd
+from .tof import tof_to_voxel_tensor
+
+
+# ============================================================
+# L. 利き手反転正規化 (Y/Z flip for left‑handed)
+# ============================================================
+from typing import Sequence
+
+def handedness_correction_v2(
+    df: pd.DataFrame,
+    *,
+    imu_prefixes: Sequence[str] = ("acc", "gyro", "rot", "mag"),
+    apply_tof_mirror: bool = True,
+) -> pd.DataFrame:
+    """
+    左利き (handedness==0) サンプルを右利き座標系に正規化する。
+
+    1. IMU (acc/gyro/rot/mag) の Y・Z 軸を符号反転
+       - rot_w は反転しない
+    2. ToF センサは左右ピクセルを鏡像ミラー (値はそのまま)
+       - 値の符号反転は行わない
+    """
+    df = df.copy()
+    left = df["handedness"] == 0
+
+    # --- 1) IMU の Y/Z 反転 ------------------------------------------
+    axis_sign = {"x": 1, "y": -1, "z": -1, "w": 1}       # rot_w は 1
+    for pre in imu_prefixes:
+        axes = ("w", "x", "y", "z") if pre == "rot" else ("x", "y", "z")
+        for ax in axes:
+            col = f"{pre}_{ax}"
+            if col in df.columns:
+                df.loc[left, col] *= axis_sign[ax]
+
+    # --- 2) ToF 水平ミラー -------------------------------------------
+    if apply_tof_mirror:
+        tof_cols = [c for c in df.columns if c.startswith("tof_")]
+        if tof_cols:  # mirror_tof_rows は既存関数を流用
+            df.loc[left, tof_cols] = mirror_tof_rows(df.loc[left, :], tof_cols)
+
+    return df
+
+
+def augment_handedness_flip(
+    df: pd.DataFrame,
+    *,
+    imu_prefixes: Sequence[str] = ("acc", "gyro", "rot", "mag"),
+    apply_tof_mirror: bool = True,
+) -> pd.DataFrame:
+    """左右反転したデータを追加して返すデータ拡張用関数"""
+    df_flip = df.copy()
+
+    # IMU の Y/Z 軸を反転させる
+    for pre in imu_prefixes:
+        axes = ("w", "x", "y", "z") if pre == "rot" else ("x", "y", "z")
+        for ax in axes:
+            col = f"{pre}_{ax}"
+            if col in df_flip.columns and ax in {"y", "z"}:
+                df_flip[col] = -df_flip[col]
+
+    # ToF の左右ピクセルを鏡像ミラー
+    if apply_tof_mirror:
+        tof_cols = [c for c in df_flip.columns if c.startswith("tof_")]
+        if tof_cols:
+            df_flip = mirror_tof_rows(df_flip, tof_cols)
+
+    # 利き手ラベルを反転
+    if "handedness" in df_flip.columns:
+        df_flip["handedness"] = 1 - df_flip["handedness"]
+
+    # 既存の subject/sequence_id と被らないようオフセット
+    if "subject" in df_flip.columns:
+        df_flip["subject"] = df_flip["subject"] + df["subject"].max() + 1
+    if "sequence_id" in df_flip.columns:
+        df_flip["sequence_id"] = df_flip["sequence_id"] + df["sequence_id"].max() + 1
+
+    # 元データと結合
+    return pd.concat([df, df_flip], ignore_index=True)
+
+
+import re
+# ── 1. ToF の水平ミラー（左右反転）関数 ─────────────────────────
+def mirror_tof_rows(df: pd.DataFrame, tof_cols: list[str]) -> pd.DataFrame:
+    """
+    各行の ToF ピクセル(8×8) を水平ミラーします。
+    df[tof_cols] の形状は (N, 64×D) を想定。
+    """
+    pattern = re.compile(r"tof_(\d+)_v(\d+)")
+    # センサIDごとのグループを取得
+    sensor_ids = sorted({int(pattern.match(c).group(1)) for c in tof_cols})
+    out = df.copy()
+    for sid in sensor_ids:
+        # 当該センサの 64 列を時系列順に並べて (N, H, W) にreshape
+        cols = [f"tof_{sid}_v{i}" for i in range(64)]
+        arr = df[cols].to_numpy().reshape(-1, 8, 8)
+        # W方向を反転
+        flipped = arr[:, :, ::-1]
+        # 元に戻して DataFrame に代入
+        out.loc[:, cols] = flipped.reshape(-1, 64)
+    return out
+
+
+# ============================================================
+# Utility : Missing-value Cleaning
+# =============================
+
+# =========================================================
+# D) センサータイプごとに欠損値を適切に処理する関数
+# =========================================================
+
+def clean_sensor_missing_values(
+    df: pd.DataFrame,
+    sensor_type_groups: dict,
+    acc_clip: tuple = (-40.0, 40.0),
+) -> pd.DataFrame:
+    """
+    センサータイプごとに欠損値を適切に処理する関数（調査結果に基づく）
+    
+    ── Rules (調査結果ベース) ────────────────────────────────
+      • Accelerometer :   0 / −1 は正当値 → 極端値 |value|>acc_clip を NaN
+      • Rotation      :   NaN のみ欠損値
+      • ToF_Sensor    :   NaN, -1 および -1 未満 → 欠損値 (NaN 化)
+      • Thermal       :   NaN のみ欠損値
+    ─────────────────────────────────────────────────────────
+    """
+    df = df.copy()
+
+    # ------------------ 1) Accelerometer ------------------
+    acc_cols = sensor_type_groups.get("Accelerometer", [])
+    if acc_cols:
+        # |value| > clip 上限を欠測とみなす
+        df[acc_cols] = df[acc_cols].where(
+            df[acc_cols].abs().le(acc_clip[1]), np.nan
+        )
+
+    # ------------------ 2) ToF_Sensor ---------------------
+    tof_cols = sensor_type_groups.get("ToF_Sensor", [])
+    if tof_cols:
+        # a) 上限超え (255 以上) は NaN
+        df[tof_cols] = df[tof_cols].where(df[tof_cols] <= 254, np.nan)
+        # b) -2 以下も NaN （ハードエラー）
+        df[tof_cols] = df[tof_cols].where(df[tof_cols] >= -1, np.nan)
+        # ※ -1 は “反射なし” → そのまま残す
+
+    # ------------------ 3) Rotation / Thermal -------------
+    # 既定では NaN のみ欠測 → 追加処理不要
+    return df
+
+
+# =========================================================
+# A) 補間パラメータ（調査結果を反映）
+# =========================================================
+# 外部ファイルで定義
+
+# =========================================================
+# B) クォータニオン SLERP と ToF 用補間関数
+# =========================================================
+from scipy.spatial.transform import Rotation, Slerp
+import numpy as np
+import pandas as pd
+
+def _interpolate_quaternion_block(df, cols, time_col, limit):
+    q = df[cols].to_numpy(float)
+
+    # 0-norm → 欠測扱い
+    norm = np.linalg.norm(q, axis=1, keepdims=True)
+    q[norm.squeeze() < 1e-6] = np.nan
+
+    t = df[time_col].to_numpy()
+    mask_nan = np.isnan(q).any(axis=1)
+
+    i = 0
+    while i < len(q):
+        if mask_nan[i]:
+            # --- 欠測 run の [start+1 : end-1] を補間 -----------------
+            start = i - 1               # start は常に定義される
+            j = i
+            while j < len(q) and mask_nan[j]:
+                j += 1
+            end = j                      # first non-NaN idx or len(q)
+            run_len = end - start - 1
+            if start >= 0 and end < len(q) and run_len <= limit:
+                key_times = np.array([t[start], t[end]])
+                key_rots  = Rotation.from_quat(q[[start, end]])
+                slerp = Slerp(key_times, key_rots)
+                q[start+1:end] = slerp(t[start+1:end]).as_quat()
+            i = end                      # ← 欠測 run の次フレームへ
+        else:
+            i += 1                       # 欠測でない→次へ
+
+    # 補間後に正規化
+    valid = ~np.isnan(q).any(axis=1)
+    q[valid] /= np.linalg.norm(q[valid], axis=1, keepdims=True)
+    # まだ NaN があれば identity に
+    q[~valid] = np.array([1,0,0,0])
+
+    return pd.DataFrame(q, columns=cols, index=df.index)
+
+
+
+def _interpolate_tof_block(df, cols, limit, fill_value=-1):
+    """-1 は反射なし → 一時 NaN → 短ラン補間 → -1 に戻す"""
+    blk = df[cols].replace(fill_value, np.nan)
+    blk = blk.interpolate(method="linear",
+                          limit=limit,
+                          limit_direction="both")
+    return blk.fillna(fill_value)
+
+# =========================================================
+# C) 並列 & ディスク結合版クリーニング
+# =========================================================
+from joblib import Parallel, delayed
+from tqdm.auto import tqdm
+import tempfile, shutil
+from pathlib import Path
+
+def clean_missing_sensor_data_parallel_disk(
+    df: pd.DataFrame,
+    sensor_type_groups: dict[str, list[str]],
+    group_cols=("subject", "sequence_id"),
+    time_col: str = "sequence_counter",
+    interp_params: dict | None = None,
+    n_jobs: int = -1,
+    tmp_parent: str | Path = "/tmp/tmp_clean_chunks",
+    keep_tmp: bool = False,
+    keep_cols: list[str] | None = None,        # ★NEW
+) -> pd.DataFrame:
+
+    keep_cols = list(keep_cols or [])
+    base_cols = list(group_cols) + [time_col] + keep_cols
+    
+    # 0) デフォルト
+    default_params = {
+        "Accelerometer": {"method": "linear", "limit": 3},
+        "Rotation":      {"method": "slerp",  "limit": 120},
+        "ToF_Sensor":    {"method": "linear", "limit": 4, "fill_value": -1},
+        "Thermal":       {"method": "linear", "limit": 120},
+    }
+    interp_params = interp_params or default_params
+
+    # 1) ソート
+    df = df.sort_values(list(group_cols) + [time_col]).copy()
+
+    # 2) 一時ディレクトリ
+    tmp_root = Path(tmp_parent); tmp_root.mkdir(exist_ok=True)
+    tmp_dir = tempfile.mkdtemp(dir=tmp_root)
+
+    # 3) 各グループを並列補間 → parquet 保存
+    def _interpolate_and_dump(key, g,
+                            sensor_type_groups, interp_params,
+                            time_col, tmp_dir):
+
+        # --- 欠測補間 -------------------------------------------------
+        for s_type, cols in sensor_type_groups.items():
+            # World_Accelerometerの場合はスキップ
+            if s_type == "World_Accelerometer":
+                continue
+                
+            params = interp_params[s_type]
+            method = params.get("method")
+            limit  = params.get("limit", 3)
+
+            if method is None:
+                continue
+            if s_type == "Rotation":
+                g[cols] = _interpolate_quaternion_block(
+                    g, cols, time_col, limit)
+            elif s_type == "ToF_Sensor":
+                g[cols] = _interpolate_tof_block(
+                    g, cols, limit, params.get("fill_value", -1))
+            else:  # Accelerometer / Thermal
+                g[cols] = g[cols].interpolate(
+                    method=method,
+                    limit=limit,
+                    limit_direction="both"
+                )
+        # -------------------------------------------------------------
+
+        # Parquet 出力
+        subject, seq_id = key
+        # ❶ 保存したい列を計算（存在するカラムのみ）
+        all_cols = base_cols + sum(sensor_type_groups.values(), [])
+        save_cols = list(dict.fromkeys(all_cols))
+        # DataFrameに存在するカラムのみをフィルタ
+        save_cols = [col for col in save_cols if col in g.columns]
+
+
+        # ❷ サブセットを取ってから Parquet 書き出し
+        out_path = Path(tmp_dir) / f"{subject}_{seq_id}.parquet"
+        g.loc[:, save_cols].to_parquet(out_path)   # ← columns 引数を削除
+        return out_path
+
+    # ① (key, grp) を保持
+    groups = [(key, grp) for key, grp in df.groupby(list(group_cols), sort=False)]
+
+    # ② key を _interpolate_and_dump に渡す
+    paths = Parallel(n_jobs=n_jobs, backend="loky")(
+        delayed(_interpolate_and_dump)(
+            key, grp,              # ← 変更
+            sensor_type_groups,
+            interp_params,
+            time_col,
+            tmp_dir
+        )
+        for key, grp in tqdm(groups, desc="interp", unit="seq")
+    )
+    # 4) 結合
+    cleaned = pd.concat(
+        (pd.read_parquet(p) for p in tqdm(paths, desc="concat")),
+        ignore_index=True          # ← sort_index 不要に
+    )
+
+    if not keep_tmp:
+        # 削除はバックグラウンドでも可
+        import threading, shutil
+        threading.Thread(target=shutil.rmtree,
+                        args=(tmp_dir,),
+                        kwargs=dict(ignore_errors=True),
+                        daemon=True).start()
+
+    return cleaned 
+
+# ============================================================
+# I. 合成 Tabular (= A–H)
+# ============================================================
+### --- Block I Summary ---------------------------------------
+# dims: 120 | 推奨モデル: LightGBM_all / CatBoost
+# 木モデル用に Tabular 特徴を統合
+# ------------------------------------------------------------
+# （統合処理は学習パイプライン側で実施）
+
+
+# ============================================================
+# J. IMU Sliding Window Tensor
+# ============================================================
+### --- Block J Summary ---------------------------------------
+# dims: 7×256 = 1 792 | 推奨モデル: Binary-GRU / CNN-GRU
+# 局所パターン＋長期文脈を時系列テンソルで捕捉
+# ------------------------------------------------------------
+def create_sliding_windows_with_demographics(
+    df: pd.DataFrame,
+    window_size: int,
+    stride: int,
+    sensor_cols: list,
+    demographics_cols: list,
+    min_sequence_length: int = 10,
+    padding_value: float = 0.0,
+):
+    """Block B: generate fixed‑length windows and attach static demographics."""
+    X_sensor_windows, X_demographics_windows, y_windows, info = [], [], [], []
+
+    for (subject, seq_id), g in df.groupby(["subject", "sequence_id"]):
+        seq_len = len(g)
+        if seq_len < min_sequence_length:
+            continue
+        sensor = g[sensor_cols].values
+        demo = g[demographics_cols].iloc[0].values
+        
+        # Handle case where gesture column doesn't exist (e.g., test data)
+        if "gesture" in g.columns:
+            gesture = g["gesture"].iloc[0]
+        else:
+            # For test data, we don't have gesture labels
+            # We'll use a placeholder value that won't affect the model training
+            gesture = -1  # Use -1 as placeholder for test data
+        
+        need_pad = seq_len < window_size
+        if need_pad:
+            pad = np.full((window_size - seq_len, len(sensor_cols)), padding_value)
+            sensor = np.vstack([sensor, pad])
+        for s in range(0, len(sensor) - window_size + 1, stride):
+            e = s + window_size
+            X_sensor_windows.append(sensor[s:e])
+            X_demographics_windows.append(demo)
+            y_windows.append(gesture)
+            info.append({"subject": subject, "sequence_id": seq_id, "start_idx": s, "end_idx": e, "padded": need_pad})
+
+    return (
+        np.asarray(X_sensor_windows, dtype=np.float32),
+        np.asarray(X_demographics_windows, dtype=np.float32),
+        np.asarray(y_windows),
+        info,
+    )
+
+
+def create_tof_windows_with_info(
+    df: pd.DataFrame,
+    window_size: int,
+    stride: int,
+    tof_cols: list,
+    min_sequence_length: int = 10,
+    fill_value: float = 0.0,
+) -> tuple[np.ndarray, list[dict]]:
+    """Generate sliding windows for ToF voxel tensor with metadata.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe containing ToF pixel columns.
+    window_size : int
+        Length of each window.
+    stride : int
+        Step size between windows.
+    tof_cols : list
+        Column names of ToF pixels to be used.
+    min_sequence_length : int, default 10
+        Minimum sequence length to consider a sequence.
+    fill_value : float, default 0.0
+        Padding value for sequences shorter than ``window_size``.
+
+    Returns
+    -------
+    tuple[np.ndarray, list[dict]]
+        ``windows`` with shape ``(N, window_size, depth, H, W)`` and
+        ``info`` containing metadata for each window.
+    """
+
+    X_windows, info = [], []
+
+    for (subject, seq_id), g in df.groupby(["subject", "sequence_id"]):
+        seq_len = len(g)
+        if seq_len < min_sequence_length:
+            continue
+
+        tensor = tof_to_voxel_tensor(g[tof_cols], fill_value=fill_value)
+        need_pad = seq_len < window_size
+        if need_pad:
+            pad = np.full(
+                (window_size - seq_len,) + tensor.shape[1:],
+                fill_value,
+                dtype=tensor.dtype,
+            )
+            tensor = np.concatenate([tensor, pad], axis=0)
+
+        for s in range(0, len(tensor) - window_size + 1, stride):
+            e = s + window_size
+            X_windows.append(tensor[s:e])
+            info.append(
+                {
+                    "subject": subject,
+                    "sequence_id": seq_id,
+                    "start_idx": s,
+                    "end_idx": e,
+                    "padded": need_pad,
+                }
+            )
+
+    return np.asarray(X_windows, dtype=np.float32), info
+
+
+
+
+# ============================================================
+# C. 正規化ユーティリティ (sensor / tabular)
+# ============================================================
+
+def normalize_sensor_data(X: np.ndarray):
+    """Block C‑1: z‑score normalisation for sensor windows."""
+    scaler = StandardScaler()
+    n, t, f = X.shape
+    X_flat = np.nan_to_num(X.reshape(-1, f), nan=0.0)
+    X_norm = scaler.fit_transform(X_flat).reshape(n, t, f)
+    return X_norm, scaler
+
+
+def normalize_tabular_data(X: np.ndarray):
+    """Block C‑2: z‑score normalisation for demographics/tabular."""
+    scaler = StandardScaler()
+    return scaler.fit_transform(X), scaler

--- a/submissions/v40_128/src/utils/tof.py
+++ b/submissions/v40_128/src/utils/tof.py
@@ -1,0 +1,36 @@
+
+"""ToF (Time-of-Flight) related utilities."""
+
+import numpy as np
+import pandas as pd
+
+
+# ============================================================
+# K. ToF 3D Voxel Tensor
+# ============================================================
+### --- Block K Summary ---------------------------------------
+# dims: 20 480 | 推奨モデル: ToF-3D-CNN
+# 顔・対象物との空間的接近パターンを 3D で表現
+# ------------------------------------------------------------
+
+def tof_to_voxel_tensor(df: pd.DataFrame, fill_value: float = -1.0, prefix: str = "tof_") -> np.ndarray:
+    """Block L: convert ToF pixel columns → (T, depth, H, W) tensor."""
+    import re
+    pat = re.compile(fr"^{prefix}(\d+)_v(\d+)$")
+    matches = [(c, pat.match(c)) for c in df.columns]
+    sensors = sorted({int(m.group(1)) for _, m in matches if m})
+    idxs = [int(m.group(2)) for _, m in matches if m]
+    if not sensors:
+        raise ValueError("No ToF columns found")
+    W = H = int(np.sqrt(max(idxs) + 1))
+    T = len(df)
+    D = len(sensors)
+    tensor = np.full((T, D, H, W), fill_value, dtype=np.float32)
+    for d, sn in enumerate(sensors):
+        for idx in range(H * W):
+            col = f"{prefix}{sn}_v{idx}"
+            if col in df.columns:
+                vals = df[col].replace(-1, fill_value).to_numpy(dtype=np.float32)
+                r, c = divmod(idx, W)
+                tensor[:, d, r, c] = vals
+    return tensor

--- a/submissions/v40_64/cmi-2025-demo-submission.ipynb
+++ b/submissions/v40_64/cmi-2025-demo-submission.ipynb
@@ -1,0 +1,362 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "# CMI Behavior Detection with Multimodal V40 (ws64 only)\n",
+        "\n",
+        "This notebook uses a single 5-fold multimodal model (window size 64) for gesture recognition."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2025-07-22 09:02:38.164453: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+            "2025-07-22 09:02:39.573434: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+            "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+            "E0000 00:00:1753142560.060496  608809 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+            "E0000 00:00:1753142560.185875  608809 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+            "W0000 00:00:1753142561.290751  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1753142561.290781  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1753142561.290782  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1753142561.290783  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "2025-07-22 09:02:41.406674: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+            "To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+            "INFO:src.inference_pipeline:Loading configurations...\n",
+            "INFO:src.inference_pipeline:Loading preprocessors...\n",
+            "INFO:utils.pipeline:Loading Preprocessor from preprocessor_64.pkl\n",
+            "INFO:utils.pipeline:Loading Preprocessor from preprocessor_128.pkl\n",
+            "INFO:src.inference_pipeline:Preprocessors loaded successfully.\n",
+            "INFO:src.inference_pipeline:Loading ws64 models...\n",
+            "I0000 00:00:1753142598.792061  608809 gpu_device.cc:2019] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 5660 MB memory:  -> device: 0, name: NVIDIA GeForce RTX 3050, pci bus id: 0000:01:00.0, compute capability: 8.6\n",
+            "INFO:src.inference_pipeline:Loading ws128 models...\n",
+            "INFO:src.inference_pipeline:Loaded 5 ws64 models and 5 ws128 models.\n"
+          ]
+        }
+      ],
+      "source": [
+        "import os\n",
+        "from pathlib import Path\n",
+        "import polars as pl\n",
+        "\n",
+        "import kaggle_evaluation.cmi_inference_server\n",
+        "\n",
+        "from src.inference_pipeline import predict_one\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def predict(sequence: pl.DataFrame, demographics: pl.DataFrame) -> str:\n",
+        "    return predict_one(sequence, demographics)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "INFO:src.inference_pipeline:Starting ensemble inference for one sample.\n",
+            "INFO:src.inference_pipeline:Processing with ws64 preprocessor...\n",
+            "INFO:utils.pipeline:Transforming dataframe of shape (79, 343)\n",
+            "/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/feature_engineering.py:171: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+            "  df[flag] = df[cols].isna().all(axis=1)\n",
+            "/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/feature_engineering.py:171: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+            "  df[flag] = df[cols].isna().all(axis=1)\n",
+            "/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/feature_engineering.py:171: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+            "  df[flag] = df[cols].isna().all(axis=1)\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "fcb1e82527644496a2a063d38d175129",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "interp:   0%|          | 0/1 [00:00<?, ?seq/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "ec76f94576054c2fab51a21ec36db505",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "concat:   0%|          | 0/1 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "INFO:utils.pipeline:Building windows (size=64, stride=32, min_len=20)\n",
+            "INFO:utils.pipeline:Windows shapes: X_sensor=(1, 64, 18), X_demo=(1, 7), y=(1,)\n",
+            "INFO:utils.pipeline:Window tensor shape (1, 64, 18)\n",
+            "INFO:utils.pipeline:Building tabular features (wavelet=True, tda=True, tof_event=False, temp_grad=False)\n",
+            "INFO:utils.pipeline:Tabular features shape (1, 409)\n",
+            "ERROR:src.inference_pipeline:Error in ws64 processing: X has 409 features, but StandardScaler is expecting 392 features as input.\n",
+            "ERROR:grpc._server:Exception calling application: X has 409 features, but StandardScaler is expecting 392 features as input.\n",
+            "Traceback (most recent call last):\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/grpc/_server.py\", line 610, in _call_behavior\n",
+            "    response_or_iterator = behavior(argument, context)\n",
+            "                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/relay.py\", line 354, in Send\n",
+            "    response_payload = _serialize(response_function(*args, **kwargs))\n",
+            "                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/tmp/ipykernel_608809/132370808.py\", line 2, in predict\n",
+            "    return predict_one(sequence, demographics)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/inference_pipeline.py\", line 109, in predict_one\n",
+            "    data_64 = preprocessor_64.transform(combined_df.copy(), use_cache=False)\n",
+            "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/pipeline.py\", line 762, in transform\n",
+            "    tab_normalized = self.tab_scaler.transform(tab_clean)\n",
+            "                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/utils/_set_output.py\", line 157, in wrapped\n",
+            "    data_to_wrap = f(self, X, *args, **kwargs)\n",
+            "                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/preprocessing/_data.py\", line 1006, in transform\n",
+            "    X = self._validate_data(\n",
+            "        ^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/base.py\", line 626, in _validate_data\n",
+            "    self._check_n_features(X, reset=reset)\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/base.py\", line 415, in _check_n_features\n",
+            "    raise ValueError(\n",
+            "ValueError: X has 409 features, but StandardScaler is expecting 392 features as input.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "✅ TDA処理前: NaN値なし\n"
+          ]
+        },
+        {
+          "ename": "GatewayRuntimeError",
+          "evalue": "(<GatewayRuntimeErrorType.SERVER_RAISED_EXCEPTION: 3>, 'X has 409 features, but StandardScaler is expecting 392 features as input.')",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mGatewayRuntimeError\u001b[39m                       Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 17\u001b[39m\n\u001b[32m     10\u001b[39m     inference_server.run_local_gateway(\n\u001b[32m     11\u001b[39m         data_paths=(\n\u001b[32m     12\u001b[39m             \u001b[33m'\u001b[39m\u001b[33m/kaggle/input/cmi-detect-behavior-with-sensor-data/test.csv\u001b[39m\u001b[33m'\u001b[39m,\n\u001b[32m     13\u001b[39m             \u001b[33m'\u001b[39m\u001b[33m/kaggle/input/cmi-detect-behavior-with-sensor-data/test_demographics.csv\u001b[39m\u001b[33m'\u001b[39m,\n\u001b[32m     14\u001b[39m         )\n\u001b[32m     15\u001b[39m     )\n\u001b[32m     16\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m17\u001b[39m     \u001b[43minference_server\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun_local_gateway\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     18\u001b[39m \u001b[43m        \u001b[49m\u001b[43mdata_paths\u001b[49m\u001b[43m=\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     19\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43m../data/split/test.csv\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     20\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43m../data/split/test_demographics.csv\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     21\u001b[39m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     22\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:149\u001b[39m, in \u001b[36mInferenceServer.run_local_gateway\u001b[39m\u001b[34m(self, data_paths, file_share_dir, *args, **kwargs)\u001b[39m\n\u001b[32m    147\u001b[39m     \u001b[38;5;28mself\u001b[39m.gateway.run()\n\u001b[32m    148\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[32m--> \u001b[39m\u001b[32m149\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m err \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    150\u001b[39m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[32m    151\u001b[39m     \u001b[38;5;28mself\u001b[39m.server.stop(\u001b[32m0\u001b[39m)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:147\u001b[39m, in \u001b[36mInferenceServer.run_local_gateway\u001b[39m\u001b[34m(self, data_paths, file_share_dir, *args, **kwargs)\u001b[39m\n\u001b[32m    145\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m    146\u001b[39m     \u001b[38;5;28mself\u001b[39m.gateway = \u001b[38;5;28mself\u001b[39m._get_gateway_for_test(data_paths, file_share_dir, *args, **kwargs)\n\u001b[32m--> \u001b[39m\u001b[32m147\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mgateway\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    148\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[32m    149\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m err \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:105\u001b[39m, in \u001b[36mGateway.run\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    102\u001b[39m     \u001b[38;5;28mself\u001b[39m.write_result(error)\n\u001b[32m    103\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m error:\n\u001b[32m    104\u001b[39m     \u001b[38;5;66;03m# For local testing\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m105\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m error\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:84\u001b[39m, in \u001b[36mGateway.run\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m     82\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m     83\u001b[39m     \u001b[38;5;28mself\u001b[39m.unpack_data_paths()\n\u001b[32m---> \u001b[39m\u001b[32m84\u001b[39m     predictions, row_ids = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mget_all_predictions\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     85\u001b[39m     \u001b[38;5;28mself\u001b[39m.write_submission(predictions, row_ids)\n\u001b[32m     86\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m kaggle_evaluation.core.base_gateway.GatewayRuntimeError \u001b[38;5;28;01mas\u001b[39;00m gre:\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:56\u001b[39m, in \u001b[36mGateway.get_all_predictions\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m     54\u001b[39m all_row_ids = []\n\u001b[32m     55\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m data_batch, row_ids \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.generate_data_batches():\n\u001b[32m---> \u001b[39m\u001b[32m56\u001b[39m     predictions = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mpredict\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43mdata_batch\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     57\u001b[39m     \u001b[38;5;28mself\u001b[39m.validate_prediction_batch(predictions, row_ids)\n\u001b[32m     58\u001b[39m     all_predictions.append(predictions)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:72\u001b[39m, in \u001b[36mGateway.predict\u001b[39m\u001b[34m(self, *args, **kwargs)\u001b[39m\n\u001b[32m     70\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m.client.send(\u001b[33m'\u001b[39m\u001b[33mpredict\u001b[39m\u001b[33m'\u001b[39m, *args, **kwargs)\n\u001b[32m     71\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m---> \u001b[39m\u001b[32m72\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mhandle_server_error\u001b[49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mpredict\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/base_gateway.py:257\u001b[39m, in \u001b[36mBaseGateway.handle_server_error\u001b[39m\u001b[34m(self, exception, endpoint)\u001b[39m\n\u001b[32m    255\u001b[39m     message_match = re.search(\u001b[33m'\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mException calling application: (.*)\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m'\u001b[39m, exception_str, re.IGNORECASE)\n\u001b[32m    256\u001b[39m     message = message_match.group(\u001b[32m1\u001b[39m) \u001b[38;5;28;01mif\u001b[39;00m message_match \u001b[38;5;28;01melse\u001b[39;00m exception_str\n\u001b[32m--> \u001b[39m\u001b[32m257\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m GatewayRuntimeError(GatewayRuntimeErrorType.SERVER_RAISED_EXCEPTION, message) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    258\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(exception, grpc._channel._InactiveRpcError):\n\u001b[32m    259\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m GatewayRuntimeError(GatewayRuntimeErrorType.SERVER_CONNECTION_FAILED, exception_str) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n",
+            "\u001b[31mGatewayRuntimeError\u001b[39m: (<GatewayRuntimeErrorType.SERVER_RAISED_EXCEPTION: 3>, 'X has 409 features, but StandardScaler is expecting 392 features as input.')"
+          ]
+        }
+      ],
+      "source": [
+        "inference_server = kaggle_evaluation.cmi_inference_server.CMIInferenceServer(predict)\n",
+        "\n",
+        "def is_kaggle():\n",
+        "    return \"KAGGLE_URL_BASE\" in os.environ or Path(\"/kaggle\").exists()\n",
+        "\n",
+        "if os.getenv('KAGGLE_IS_COMPETITION_RERUN'):\n",
+        "    inference_server.serve()\n",
+        "else:\n",
+        "    if is_kaggle():\n",
+        "        inference_server.run_local_gateway(\n",
+        "            data_paths=(\n",
+        "                '/kaggle/input/cmi-detect-behavior-with-sensor-data/test.csv',\n",
+        "                '/kaggle/input/cmi-detect-behavior-with-sensor-data/test_demographics.csv',\n",
+        "            )\n",
+        "        )\n",
+        "    else:\n",
+        "        inference_server.run_local_gateway(\n",
+        "            data_paths=(\n",
+        "                '../data/split/test.csv',\n",
+        "                '../data/split/test_demographics.csv',\n",
+        "            )\n",
+        "        )\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Shape: (102, 2)\n",
+            "Columns: ['sequence_id', 'gesture']\n",
+            "First 10 rows:\n",
+            "  sequence_id                    gesture\n",
+            "0  SEQ_060707         Cheek - pinch skin\n",
+            "1  SEQ_037923              Text on phone\n",
+            "2  SEQ_028006   Forehead - pull hairline\n",
+            "3  SEQ_020034      Above ear - pull hair\n",
+            "4  SEQ_016979        Eyebrow - pull hair\n",
+            "5  SEQ_037140      Above ear - pull hair\n",
+            "6  SEQ_062937             Neck - scratch\n",
+            "7  SEQ_025391          Neck - pinch skin\n",
+            "8  SEQ_064204  Pull air toward your face\n",
+            "9  SEQ_063950         Cheek - pinch skin\n",
+            "Value counts:\n",
+            "gesture\n",
+            "Neck - scratch                                20\n",
+            "Cheek - pinch skin                            13\n",
+            "Neck - pinch skin                             13\n",
+            "Text on phone                                 11\n",
+            "Wave hello                                     7\n",
+            "Eyebrow - pull hair                            6\n",
+            "Eyelash - pull hair                            6\n",
+            "Above ear - pull hair                          5\n",
+            "Forehead - scratch                             5\n",
+            "Forehead - pull hairline                       3\n",
+            "Pull air toward your face                      3\n",
+            "Glasses on/off                                 3\n",
+            "Pinch knee/leg skin                            3\n",
+            "Write name in air                              2\n",
+            "Feel around in tray and pull out an object     1\n",
+            "Write name on leg                              1\n",
+            "Name: count, dtype: int64\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Check submission file\n",
+        "import pandas as pd\n",
+        "df = pd.read_parquet('submission.parquet')\n",
+        "print('Shape:', df.shape)\n",
+        "print('Columns:', df.columns.tolist())\n",
+        "print('First 10 rows:')\n",
+        "print(df.head(10))\n",
+        "print('Value counts:')\n",
+        "print(df['gesture'].value_counts())\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "CMI評価指標計算開始...\n",
+            "y_true shape: (102,), y_pred shape: (102,)\n",
+            "ラベル変換完了: 102 samples\n",
+            "データ中のジェスチャー: 18種類\n",
+            "Binary分類 - Target: 64, Non-Target: 38\n",
+            "Binary F1: 0.6963\n",
+            "Macro F1: 0.1124\n",
+            "CMI Score: 0.4044\n",
+            "Test Accuracy: 0.0588\n",
+            "CMI Score: 0.4044, Binary F1: 0.6963, Macro F1: 0.1124, Accuracy: 0.0588\n"
+          ]
+        }
+      ],
+      "source": [
+        "import pandas as pd\n",
+        "from src.utils.cmi_evaluation import calculate_cmi_score\n",
+        "\n",
+        "# 例: 推論結果\n",
+        "df_pred = pd.read_parquet('submission.parquet')  # またはcsv等\n",
+        "# 例: 正解ラベル\n",
+        "df_true = pd.read_csv('../data/split/test_labels.csv')\n",
+        "\n",
+        "# ラベル名が一致している前提\n",
+        "y_pred = df_pred['gesture'].values\n",
+        "y_true = df_true['gesture'].values\n",
+        "\n",
+        "# 必要ならLabelEncoderでエンコード\n",
+        "from sklearn.preprocessing import LabelEncoder\n",
+        "le = LabelEncoder()\n",
+        "le.fit(list(y_true) + list(y_pred))\n",
+        "y_true_enc = le.transform(y_true)\n",
+        "y_pred_enc = le.transform(y_pred)\n",
+        "\n",
+        "# CMIスコア計算\n",
+        "cmi_score, binary_f1, macro_f1, test_acc = calculate_cmi_score(y_pred_enc, y_true_enc, label_encoder=le, verbose=True)\n",
+        "print(f'CMI Score: {cmi_score:.4f}, Binary F1: {binary_f1:.4f}, Macro F1: {macro_f1:.4f}, Accuracy: {test_acc:.4f}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Target / Non‑target 比率 (%)\n",
+            "sequence_type  Non-Target  Target\n",
+            "fold                             \n",
+            "0                    39.7    60.3\n",
+            "1                    40.4    59.6\n",
+            "2                    40.3    59.7\n",
+            "3                    40.4    59.6\n",
+            "4                    40.0    60.0\n"
+          ]
+        }
+      ],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.5"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/submissions/v40_64/config_ws64.yaml
+++ b/submissions/v40_64/config_ws64.yaml
@@ -1,0 +1,1 @@
+../../config/config_v40_ws64.yaml

--- a/submissions/v40_64/models_64
+++ b/submissions/v40_64/models_64
@@ -1,0 +1,1 @@
+../../output/experiments/preprocess_v2_ws64/models

--- a/submissions/v40_64/prepare.sh
+++ b/submissions/v40_64/prepare.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Create necessary directories
+mkdir -p src/utils
+mkdir -p src/trainers
+
+# Copy essential source files
+cp -p ../../src/utils/pipeline.py ./src/utils/
+cp -p ../../src/utils/kaggle.py ./src/utils/
+cp -p ../../src/utils/cmi_evaluation.py ./src/utils/
+cp -p ../../src/utils/config_utils.py ./src/utils/
+cp -p ../../src/trainers/multimodal_trainer_v40.py ./src/trainers/
+cp -p ../../src/utils/preprocessing.py ./src/utils/
+cp -p ../../src/utils/tof.py ./src/utils/
+cp -p ../../src/utils/imu.py ./src/utils/
+cp -p ../../src/utils/feature_engineering.py ./src/utils/
+cp -p ../../src/utils/io_utils.py ./src/utils/
+
+
+# Link ws64 model and preprocessor
+ln -s ../../output/experiments/preprocess_v2_ws64/models models_64
+ln -s ../../output/experiments/preprocess_v2_ws64/preprocessed/preprocessor.pkl preprocessor_64.pkl
+# Link config file
+ln -s ../../config/config_v40_ws64.yaml config_ws64.yaml
+
+# Create a dummy kaggle_evaluation link if it doesn't exist, for local testing
+if [ ! -d "kaggle_evaluation" ]; then
+    ln -s ../../data/kaggle_evaluation kaggle_evaluation
+fi
+

--- a/submissions/v40_64/src/inference_pipeline.py
+++ b/submissions/v40_64/src/inference_pipeline.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+import numpy as np
+import polars as pl
+import pandas as pd
+import tensorflow as tf
+import logging
+
+# Add the submission-specific src directory to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from utils.pipeline import Preprocessor
+from utils.config_utils import load_config
+from utils.kaggle import is_kaggle
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def load_model_and_preprocessor():
+    """Load ws64 model and preprocessor."""
+    if is_kaggle():
+        base_path = Path("/kaggle/input/cmi-v40-ws64")
+        models_dir = base_path / "models_64"
+        preprocessor_path = base_path / "preprocessor_64.pkl"
+        config_path = base_path / "config_ws64.yaml"
+    else:
+        models_dir = Path("models_64")
+        preprocessor_path = Path("preprocessor_64.pkl")
+        config_path = Path("config_ws64.yaml")
+
+    logger.info("Loading configuration...")
+    config = load_config(config_path) if config_path.exists() else None
+
+    logger.info("Loading preprocessor...")
+    preprocessor = Preprocessor.load(preprocessor_path)
+    if config:
+        preprocessor.config.update(config)
+
+    logger.info("Loading models...")
+    models = []
+    for fold in range(1, 6):
+        model_path = models_dir / f"multimodal_model_v40_fold{fold}.keras"
+        if model_path.exists():
+            models.append(tf.keras.models.load_model(model_path))
+        else:
+            raise FileNotFoundError(f"Model not found: {model_path}")
+    logger.info(f"Loaded {len(models)} ws64 models.")
+    return preprocessor, models
+
+
+preprocessor, models = load_model_and_preprocessor()
+
+
+def predict_one(sequence: pl.DataFrame, demographics: pl.DataFrame) -> str:
+    """Run inference using ws64 model set."""
+    seq_df = sequence.to_pandas()
+    demo_df = demographics.to_pandas()
+    combined_df = seq_df.merge(demo_df, on="subject", how="left")
+
+    data = preprocessor.transform(combined_df.copy(), use_cache=False)
+    inputs = [
+        data["windows"],
+        data["demographics"],
+        data["tabular"],
+        data["tof_windows"],
+    ]
+
+    preds = [model.predict(inputs, verbose=0) for model in models]
+    avg_pred = np.mean(preds, axis=0)
+
+    label_index = np.argmax(avg_pred, axis=1)[0]
+    if hasattr(preprocessor, "label_encoder") and preprocessor.label_encoder is not None:
+        return preprocessor.label_encoder.inverse_transform([label_index])[0]
+    return f"gesture_{label_index}"

--- a/submissions/v40_64/src/trainers/multimodal_trainer_v40.py
+++ b/submissions/v40_64/src/trainers/multimodal_trainer_v40.py
@@ -1,0 +1,614 @@
+"""多モダリティ学習用トレーナー
+
+IMUウィンドウ、人口統計、表形式特徴量、ToFボクセルの4種類の前処理済みデータに加え、
+ToFイベント特徴量や温度勾配特徴量などの拡張タブular特徴量を利用して学習を行う。
+少数クラスを考慮するため、``_train_fold`` では
+``sklearn.utils.class_weight.compute_class_weight`` を使ってクラス重みを計算し、
+``model.fit()`` に ``class_weight`` として渡す。
+"""
+
+from __future__ import annotations
+
+import os
+import json
+import pickle
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.model_selection import (
+    train_test_split,
+    StratifiedGroupKFold,
+)
+from sklearn.metrics import classification_report, f1_score
+from sklearn.utils.class_weight import compute_class_weight
+
+from src.utils.cmi_evaluation import calculate_cmi_score
+from src.utils.pipeline import Preprocessor
+import tensorflow as tf
+from tensorflow import keras
+
+
+class MultimodalTrainerV40:
+    """多モダリティモデル学習管理クラス（v40）"""
+
+    def __init__(self, experiment_name: str = "multimodal") -> None:
+        self.experiment_name = experiment_name
+        self.base_dir = Path("output/experiments") / experiment_name
+        self.data_dir = self.base_dir / "preprocessed"
+        self.model_dir = self.base_dir / "models"
+        self.result_dir = self.base_dir / "results"
+
+        self.model_dir.mkdir(parents=True, exist_ok=True)
+        self.result_dir.mkdir(parents=True, exist_ok=True)
+
+        print(f"Experiment name: {self.experiment_name}")
+        print(f"Data directory: {self.data_dir}")
+
+    def _resnet_block_3d(self, x: tf.Tensor, filters: int, kernel_size: int = 3, stride: int = 1) -> tf.Tensor:
+        """3D ResNet ブロック"""
+        shortcut = x
+
+        # メインパス
+        y = keras.layers.Conv3D(filters, kernel_size, strides=stride, padding="same")(x)
+        y = keras.layers.BatchNormalization()(y)
+        y = keras.layers.ReLU()(y)
+
+        y = keras.layers.Conv3D(filters, kernel_size, padding="same")(y)
+        y = keras.layers.BatchNormalization()(y)
+
+        # ショートカットパス
+        if stride != 1 or x.shape[-1] != filters:
+            shortcut = keras.layers.Conv3D(filters, 1, strides=stride, padding="same")(shortcut)
+            shortcut = keras.layers.BatchNormalization()(shortcut)
+
+        # Add & ReLU
+        y = keras.layers.Add()([y, shortcut])
+        y = keras.layers.ReLU()(y)
+        y = keras.layers.SpatialDropout3D(0.2)(y)
+        return y
+
+    def load_all_data(self) -> Dict[str, np.ndarray]:
+        """各モダリティの前処理済みデータをすべて読み込む
+
+        追加で ``train_info.pkl`` を読み込み、``subject`` または ``sequence_id``
+        の配列を ``groups`` キーで返す。
+        """
+        print("前処理済みデータを読み込み中...")
+
+        def _load(name: str) -> np.ndarray:
+            npy = self.data_dir / f"{name}.npy"
+            pkl = self.data_dir / f"{name}.pkl"
+            if npy.exists():
+                return np.load(npy)
+            if pkl.exists():
+                with open(pkl, "rb") as f:
+                    return pickle.load(f)
+            raise FileNotFoundError(f"{name} ファイルが見つかりません")
+
+        X_sensor = _load("train_windows")
+        X_demo = _load("train_demographics")
+        X_tab = _load("train_tabular")
+        X_tab = X_tab.astype(np.float32)
+        X_tof = _load("train_tof_windows")
+        y = _load("train_labels")
+        info = _load("train_info")
+
+        if isinstance(info, list) and len(info) > 0 and isinstance(info[0], dict):
+            groups = np.array([
+                d.get("subject") for d in info
+            ])
+        else:
+            groups = np.asarray(info)
+
+        print(f"センサー: {X_sensor.shape}")
+        print(f"人口統計: {X_demo.shape}")
+        print(f"表形式: {X_tab.shape}")
+        print(f"ToF: {X_tof.shape}")
+        print(f"ラベル: {y.shape}")
+        print(f"グループ数: {len(groups)}")
+
+        return {
+            "sensor": X_sensor,
+            "demographics": X_demo,
+            "tabular": X_tab,
+            "tof": X_tof,
+            "labels": y,
+            "groups": groups,
+        }
+
+    def build_multimodal_model(
+        self,
+        sensor_shape: tuple,
+        demo_shape: int,
+        tab_shape: int,
+        tof_shape: tuple,
+        num_classes: int,
+        *,
+        use_attention: bool = False,
+    ) -> keras.Model:
+        """タワー型統合ネットワークを構築"""
+        # 1. IMU Tower (Bidirectional LSTM)
+        sensor_input = keras.Input(shape=sensor_shape, name="sensor")
+        x1 = keras.layers.Masking()(sensor_input)
+        x1 = keras.layers.Bidirectional(keras.layers.LSTM(32))(x1)
+
+        # 2. Demographics Tower
+        demo_input = keras.Input(shape=(demo_shape,), name="demo")
+        x2 = keras.layers.Dense(32, activation="relu")(demo_input)
+
+        # 3. Tabular Tower (Residual Connection)
+        tab_input = keras.Input(shape=(tab_shape,), name="tabular")
+        x3_base = keras.layers.Dense(64, activation="relu")(tab_input)
+        x3_res = keras.layers.Dense(64, activation="relu")(x3_base)
+        x3 = keras.layers.Add()([x3_base, x3_res])
+
+        # 4. ToF Tower (3D ResNet)
+        tof_input = keras.Input(shape=tof_shape, name="tof")
+        x4 = self._resnet_block_3d(tof_input, filters=16, stride=2)
+        x4 = self._resnet_block_3d(x4, filters=32, stride=2)
+        if use_attention:
+            x4 = keras.layers.SpatialDropout3D(0.2)(x4)
+        x4 = keras.layers.GlobalAveragePooling3D()(x4)
+
+        if use_attention:
+            # IMU と ToF 特徴量間でアテンションを計算
+            q = keras.layers.Reshape((1, 64))(keras.layers.Dense(64)(x1))
+            v = keras.layers.Reshape((1, 64))(keras.layers.Dense(64)(x4))
+            attn = keras.layers.MultiHeadAttention(num_heads=4, key_dim=64)(q, v)
+            attn = keras.layers.Flatten()(attn)
+            merged = keras.layers.concatenate([attn, x2, x3])
+        else:
+            merged = keras.layers.concatenate([x1, x2, x3, x4])
+        merged = keras.layers.Dense(64, activation="relu")(merged)
+        merged = keras.layers.Dropout(0.3)(merged)
+        output = keras.layers.Dense(num_classes, activation="softmax")(merged)
+
+        model = keras.Model(
+            inputs=[sensor_input, demo_input, tab_input, tof_input], outputs=output
+        )
+
+        lr_schedule = keras.optimizers.schedules.ExponentialDecay(
+            initial_learning_rate=1e-3,
+            decay_steps=1000,
+            decay_rate=0.96,
+            staircase=True,
+        )
+        optimizer = keras.optimizers.Adam(learning_rate=lr_schedule)
+
+        model.compile(
+            optimizer=optimizer,
+            loss="sparse_categorical_crossentropy",
+            metrics=["accuracy"],
+        )
+        print(model.summary())
+        return model
+
+    def _train_fold(
+        self,
+        X_s: np.ndarray,
+        X_d: np.ndarray,
+        X_t: np.ndarray,
+        X_f: np.ndarray,
+        y: np.ndarray,
+        train_idx: np.ndarray,
+        val_idx: np.ndarray,
+        *,
+        epochs: int = 50,
+        batch_size: int = 32,
+        use_attention: bool = False,
+    ) -> tuple[keras.Model, keras.callbacks.History, float, float]:
+        """単一foldでモデルを学習しF1スコアを返す"""
+        model = self.build_multimodal_model(
+            sensor_shape=X_s.shape[1:],
+            demo_shape=X_d.shape[1],
+            tab_shape=X_t.shape[1],
+            tof_shape=X_f.shape[1:],
+            num_classes=len(np.unique(y)),
+            use_attention=use_attention,
+        )
+        classes = np.unique(y)
+        weights = compute_class_weight(class_weight="balanced", classes=classes, y=y[train_idx])
+        class_weight = {cls: w for cls, w in zip(classes, weights)}
+        history = model.fit(
+            [X_s[train_idx], X_d[train_idx], X_t[train_idx], X_f[train_idx]],
+            y[train_idx],
+            validation_data=(
+                [X_s[val_idx], X_d[val_idx], X_t[val_idx], X_f[val_idx]],
+                y[val_idx],
+            ),
+            epochs=epochs,
+            batch_size=batch_size,
+            class_weight=class_weight,
+            callbacks=[keras.callbacks.EarlyStopping(patience=10, restore_best_weights=True)],
+            verbose=1,
+        )
+        preds = model.predict([X_s[val_idx], X_d[val_idx], X_t[val_idx], X_f[val_idx]])
+        pred_labels = preds.argmax(axis=1)
+        f1 = f1_score(y[val_idx], pred_labels, average="macro")
+        
+        # CMI-score計算
+        cmi_score, _, _, _ = calculate_cmi_score(pred_labels, y[val_idx])
+        
+        return model, history, float(f1), float(cmi_score)
+
+    def train(
+        self,
+        data: Dict[str, np.ndarray],
+        epochs: int = 50,
+        batch_size: int = 32,
+        *,
+        use_attention: bool = False,
+    ) -> keras.callbacks.History:
+        print("=== データ型確認 ===")
+        print(f"X_sensor dtype: {data['sensor'].dtype}")
+        print(f"X_demo dtype: {data['demographics'].dtype}")
+        print(f"X_tabular dtype: {data['tabular'].dtype}")
+        print(f"X_tof dtype: {data['tof'].dtype}")
+        print(f"y dtype: {data['labels'].dtype}")
+        print(f"y unique values: {np.unique(data['labels'])}")        
+
+        X_s = data["sensor"]
+        X_d = data["demographics"]
+        X_t = data["tabular"]
+        X_f = data["tof"]
+        y = data["labels"]
+
+        Xs_train, Xs_val, yd_train, yd_val = train_test_split(
+            np.arange(len(y)), y, test_size=0.2, stratify=y, random_state=42
+        )
+        model, history, _, _ = self._train_fold(
+            X_s,
+            X_d,
+            X_t,
+            X_f,
+            y,
+            Xs_train,
+            Xs_val,
+            epochs=epochs,
+            batch_size=batch_size,
+            use_attention=use_attention,
+        )
+        self.model = model
+        self.history = history
+        return history
+
+    def train_cross_validation(
+        self,
+        data: Dict[str, np.ndarray],
+        epochs: int = 50,
+        batch_size: int = 32,
+        n_splits: int = 5,
+        groups: np.ndarray | None = None,
+        *,
+        use_attention: bool = False,
+    ) -> Dict[str, Any]:
+        """StratifiedGroupKFold を用いたクロスバリデーション学習"""
+        print("=== データ型確認 ===")
+        print(f"X_sensor dtype: {data['sensor'].dtype}")
+        print(f"X_demo dtype: {data['demographics'].dtype}")
+        print(f"X_tabular dtype: {data['tabular'].dtype}")
+        print(f"X_tof dtype: {data['tof'].dtype}")
+        print(f"y dtype: {data['labels'].dtype}")
+        print(f"y unique values: {np.unique(data['labels'])}")
+
+        X_s = data["sensor"]
+        X_d = data["demographics"]
+        X_t = data["tabular"]
+        X_f = data["tof"]
+        y = data["labels"]
+
+        if groups is None:
+            groups = data.get("groups")
+
+        skf = StratifiedGroupKFold(n_splits=n_splits, shuffle=True, random_state=42)
+        fold_scores: list[float] = []
+        fold_cmi_scores: list[float] = []
+
+        fold_histories = []
+        for fold, (tr_idx, val_idx) in enumerate(skf.split(np.arange(len(y)), y, groups), 1):
+            print(f"Fold {fold}/{n_splits}")
+            model, history, f1, cmi_score = self._train_fold(
+                X_s,
+                X_d,
+                X_t,
+                X_f,
+                y,
+                tr_idx,
+                val_idx,
+                epochs=epochs,
+                batch_size=batch_size,
+                use_attention=use_attention,
+            )
+            fold_scores.append(f1)
+            fold_cmi_scores.append(cmi_score)
+            fold_histories.append(history)
+            
+            # モデル保存
+            model_path = self.model_dir / f"multimodal_model_v40_fold{fold}.keras"
+            model.save(model_path)
+            print(f"モデル保存: {model_path}")
+            
+            # 各foldの学習履歴保存
+            history_path = self.result_dir / f"training_history_fold{fold}.json"
+            self._save_history(history, history_path)
+
+        mean_score = float(np.mean(fold_scores))
+        std_score = float(np.std(fold_scores))
+        mean_cmi = float(np.mean(fold_cmi_scores))
+        std_cmi = float(np.std(fold_cmi_scores))
+        cv_results = {
+            "fold_scores": [float(s) for s in fold_scores],
+            "fold_cmi_scores": [float(s) for s in fold_cmi_scores],
+            "mean_f1": mean_score,
+            "std_f1": std_score,
+            "mean_cmi": mean_cmi,
+            "std_cmi": std_cmi,
+        }
+
+        results_dir = Path("results")
+        results_dir.mkdir(exist_ok=True)
+        with open(results_dir / "cv_results.json", "w", encoding="utf-8") as f:
+            json.dump(cv_results, f, ensure_ascii=False, indent=2)
+        print(f"Cross-validation results saved: {results_dir / 'cv_results.json'}")
+
+        self.cv_results = cv_results
+        
+        # 学習曲線とクロスバリデーション結果をプロット
+        self.plot_training_curves(fold_histories)
+        self.plot_cross_validation_results(cv_results)
+        
+        # 最後のfoldのモデルをself.modelにセット
+        self.model = model
+        
+        return cv_results
+
+    def evaluate(
+        self,
+        data: Dict[str, np.ndarray],
+        *,
+        preprocessor_path: str | Path | None = None,
+    ) -> Dict[str, Any]:
+        X_s = data["sensor"]
+        X_d = data["demographics"]
+        X_t = data["tabular"]
+        X_f = data["tof"]
+        y = data["labels"]
+
+        preds = self.model.predict([X_s, X_d, X_t, X_f])
+        pred_labels = preds.argmax(axis=1)
+
+        label_encoder = None
+        if preprocessor_path is None:
+            preprocessor_path = self.data_dir / "preprocessor.pkl"
+        try:
+            pp_path = Path(preprocessor_path)
+            if pp_path.exists():
+                pp = Preprocessor.load(pp_path)
+                label_encoder = getattr(pp, "label_encoder", None)
+        except Exception as e:
+            print(f"label_encoder 読み込み失敗: {e}")
+
+        cmi_score, binary_f1, macro_f1, test_accuracy = calculate_cmi_score(
+            pred_labels,
+            y,
+            label_encoder=label_encoder,
+        )
+
+        report = classification_report(y, pred_labels, output_dict=True)
+
+        results = {
+            "cmi_score": float(cmi_score),
+            "binary_f1": float(binary_f1),
+            "macro_f1": float(macro_f1),
+            "test_accuracy": float(test_accuracy),
+            "report": report,
+        }
+
+        print(
+            f"CMI Score: {cmi_score:.4f} | Binary F1: {binary_f1:.4f} | "
+            f"Macro F1: {macro_f1:.4f} | Acc: {test_accuracy:.4f}"
+        )
+
+        return results
+
+    def save_model(self, path: str | Path | None = None) -> None:
+        save_path: Path
+        if path is None:
+            save_path = self.model_dir / "multimodal_model.keras"
+        else:
+            save_path = Path(path)
+        self.model.save(save_path)
+        print(f"モデル保存: {save_path}")
+
+    def _save_history(self, history, path: Path) -> None:
+        """学習履歴を保存する内部メソッド"""
+        if hasattr(history, "history"):
+            history_dict = history.history
+        else:
+            history_dict = history
+
+        with open(path, "w") as f:
+            json.dump(history_dict, f, indent=2)
+        print(f"学習履歴保存: {path}")
+
+    def save_training_history(self, path: str | Path | None = None) -> Path:
+        save_path: Path
+        if path is None:
+            save_path = self.result_dir / "training_history.json"
+        else:
+            save_path = Path(path)
+
+        if self.history is None:
+            raise ValueError("history is not set")
+
+        self._save_history(self.history, save_path)
+        return save_path
+
+    def save_evaluation_results(
+        self, results: dict, path: str | Path | None = None
+    ) -> None:
+        save_path: Path
+        if path is None:
+            save_path = self.result_dir / "evaluation_results.json"
+        else:
+            save_path = Path(path)
+
+        def _convert(obj: Any):
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+            if isinstance(obj, (np.floating, float)):
+                return float(obj)
+            if isinstance(obj, (np.integer, int)):
+                return int(obj)
+            return obj
+
+        serializable = {k: _convert(v) for k, v in results.items()}
+        with open(save_path, "w", encoding="utf-8") as f:
+            json.dump(serializable, f, ensure_ascii=False, indent=2)
+        print(f"評価結果保存: {save_path}")
+
+    def plot_training_curves(self, fold_histories: list | None = None, save_path: str | Path | None = None) -> None:
+        """学習曲線をプロットして保存する"""
+        if fold_histories is None:
+            if hasattr(self, 'history') and self.history is not None:
+                fold_histories = [self.history]
+            else:
+                print("学習履歴が見つかりません")
+                return
+
+        if save_path is None:
+            save_path = self.result_dir / "training_curves.png"
+        else:
+            save_path = Path(save_path)
+
+        # プロット設定
+        fig, axes = plt.subplots(2, 2, figsize=(15, 10))
+        fig.suptitle('Training Curves (Multimodal Model V40)', fontsize=16)
+
+        metrics = ['loss', 'accuracy']
+        for i, metric in enumerate(metrics):
+            # 訓練データ
+            ax = axes[i, 0]
+            for fold, history in enumerate(fold_histories, 1):
+                if hasattr(history, 'history'):
+                    hist = history.history
+                else:
+                    hist = history
+                
+                if metric in hist:
+                    ax.plot(hist[metric], label=f'Fold {fold}', alpha=0.7)
+            
+            ax.set_title(f'Training {metric.capitalize()}')
+            ax.set_xlabel('Epoch')
+            ax.set_ylabel(metric.capitalize())
+            ax.legend()
+            ax.grid(True, alpha=0.3)
+
+            # 検証データ
+            ax = axes[i, 1]
+            for fold, history in enumerate(fold_histories, 1):
+                if hasattr(history, 'history'):
+                    hist = history.history
+                else:
+                    hist = history
+                
+                val_metric = f'val_{metric}'
+                if val_metric in hist:
+                    ax.plot(hist[val_metric], label=f'Fold {fold}', alpha=0.7)
+            
+            ax.set_title(f'Validation {metric.capitalize()}')
+            ax.set_xlabel('Epoch')
+            ax.set_ylabel(metric.capitalize())
+            ax.legend()
+            ax.grid(True, alpha=0.3)
+
+        plt.tight_layout()
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"学習曲線保存: {save_path}")
+        plt.close()
+
+    def plot_cross_validation_results(self, cv_results: dict | None = None, save_path: str | Path | None = None) -> None:
+        """クロスバリデーション結果をプロットする"""
+        if cv_results is None:
+            if hasattr(self, 'cv_results'):
+                cv_results = self.cv_results
+            else:
+                print("クロスバリデーション結果が見つかりません")
+                return
+
+        if save_path is None:
+            save_path = self.result_dir / "cv_results.png"
+        else:
+            save_path = Path(save_path)
+
+        fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(15, 10))
+        fig.suptitle('Cross-Validation Results', fontsize=16)
+
+        # Fold別F1スコア
+        fold_scores = cv_results.get('fold_scores', [])
+        if fold_scores:
+            ax1.bar(range(1, len(fold_scores) + 1), fold_scores, alpha=0.7, color='blue')
+            ax1.axhline(y=cv_results.get('mean_f1', 0), color='red', linestyle='--', 
+                       label=f'Mean: {cv_results.get("mean_f1", 0):.4f}')
+            ax1.set_xlabel('Fold')
+            ax1.set_ylabel('F1 Score')
+            ax1.set_title('F1 Score by Fold')
+            ax1.legend()
+            ax1.grid(True, alpha=0.3)
+
+        # Fold別CMIスコア
+        fold_cmi_scores = cv_results.get('fold_cmi_scores', [])
+        if fold_cmi_scores:
+            ax2.bar(range(1, len(fold_cmi_scores) + 1), fold_cmi_scores, alpha=0.7, color='green')
+            ax2.axhline(y=cv_results.get('mean_cmi', 0), color='red', linestyle='--', 
+                       label=f'Mean: {cv_results.get("mean_cmi", 0):.4f}')
+            ax2.set_xlabel('Fold')
+            ax2.set_ylabel('CMI Score')
+            ax2.set_title('CMI Score by Fold')
+            ax2.legend()
+            ax2.grid(True, alpha=0.3)
+
+        # F1スコア統計情報
+        mean_f1 = cv_results.get('mean_f1', 0)
+        std_f1 = cv_results.get('std_f1', 0)
+        
+        ax3.text(0.1, 0.8, f'Mean F1: {mean_f1:.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.text(0.1, 0.7, f'Std F1: {std_f1:.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.text(0.1, 0.6, f'Min F1: {min(fold_scores):.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.text(0.1, 0.5, f'Max F1: {max(fold_scores):.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.set_xlim(0, 1)
+        ax3.set_ylim(0, 1)
+        ax3.set_title('F1 Score Statistics')
+        ax3.axis('off')
+
+        # CMIスコア統計情報
+        mean_cmi = cv_results.get('mean_cmi', 0)
+        std_cmi = cv_results.get('std_cmi', 0)
+        
+        ax4.text(0.1, 0.8, f'Mean CMI: {mean_cmi:.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.text(0.1, 0.7, f'Std CMI: {std_cmi:.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.text(0.1, 0.6, f'Min CMI: {min(fold_cmi_scores):.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.text(0.1, 0.5, f'Max CMI: {max(fold_cmi_scores):.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.set_xlim(0, 1)
+        ax4.set_ylim(0, 1)
+        ax4.set_title('CMI Score Statistics')
+        ax4.axis('off')
+
+        plt.tight_layout()
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"クロスバリデーション結果保存: {save_path}")
+        plt.close()
+
+
+if __name__ == "__main__":
+    trainer = MultimodalTrainerV40()
+    try:
+        data = trainer.load_all_data()
+        trainer.train(data, epochs=5)
+        trainer.save_model()
+        results = trainer.evaluate(data)
+        print(results)
+    except Exception as e:
+        print(f"エラー: {e}")

--- a/submissions/v40_64/src/utils/cmi_evaluation.py
+++ b/submissions/v40_64/src/utils/cmi_evaluation.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+CMI Competition Evaluation Module
+
+CMIコンペティション用の評価指標を計算するモジュール
+"""
+
+import numpy as np
+from sklearn.metrics import f1_score, accuracy_score
+
+# ターゲットジェスチャー（刺激行動）
+TARGET_GESTURES = [
+    'Above ear - pull hair',
+    'Cheek - pinch skin', 
+    'Eyebrow - pull hair',
+    'Eyelash - pull hair',
+    'Forehead - pull hairline',
+    'Forehead - scratch',
+    'Neck - pinch skin',
+    'Neck - scratch'
+]
+
+# 非ターゲットジェスチャー（その他の行動）
+NON_TARGET_GESTURES = [
+    'Write name on leg',
+    'Wave hello', 
+    'Glasses on/off',
+    'Text on phone',
+    'Write name in air',
+    'Feel around in tray and pull out an object',
+    'Scratch knee/leg skin',
+    'Pull air toward your face',
+    'Drink from bottle/cup',
+    'Pinch knee/leg skin'
+]
+
+def calculate_cmi_score(y_pred, y_true, label_encoder=None, verbose=False):
+    """
+    CMI コンペティション評価指標の計算
+    
+    Parameters:
+    -----------
+    y_pred : array-like
+        予測ラベル（エンコード済み）
+    y_true : array-like
+        真のラベル（エンコード済み）
+    label_encoder : LabelEncoder, optional
+        ラベルエンコーダー（None の場合は数値ラベルを直接使用）
+    verbose : bool, default=False
+        詳細ログの出力フラグ
+    
+    Returns:
+    --------
+    tuple
+        (CMI スコア, Binary F1, Macro F1, Test Accuracy)
+    """
+    try:
+        if verbose:
+            print(f"CMI評価指標計算開始...")
+            print(f"y_true shape: {np.array(y_true).shape}, y_pred shape: {np.array(y_pred).shape}")
+        
+        # numpy配列に変換
+        y_true = np.array(y_true)
+        y_pred = np.array(y_pred)
+        
+        # Test Accuracy計算
+        test_accuracy = accuracy_score(y_true, y_pred)
+        
+        if label_encoder is not None:
+            # ラベルを元の文字列に変換
+            y_true_str = label_encoder.inverse_transform(y_true)
+            y_pred_str = label_encoder.inverse_transform(y_pred)
+            
+            if verbose:
+                print(f"ラベル変換完了: {len(y_true_str)} samples")
+                unique_gestures = np.unique(np.concatenate([y_true_str, y_pred_str]))
+                print(f"データ中のジェスチャー: {len(unique_gestures)}種類")
+            
+            # 1. Binary F1: Target vs Non-Target
+            y_true_binary = np.array([1 if gesture in TARGET_GESTURES else 0 for gesture in y_true_str])
+            y_pred_binary = np.array([1 if gesture in TARGET_GESTURES else 0 for gesture in y_pred_str])
+            
+            if verbose:
+                print(f"Binary分類 - Target: {np.sum(y_true_binary)}, Non-Target: {np.sum(1-y_true_binary)}")
+            
+            # Zero division回避
+            if len(np.unique(y_true_binary)) == 1 or len(np.unique(y_pred_binary)) == 1:
+                if verbose:
+                    print("Binary分類で単一クラスのみ検出 - F1スコアを0に設定")
+                binary_f1 = 0.0
+            else:
+                binary_f1 = f1_score(y_true_binary, y_pred_binary, average='binary', zero_division='warn')
+            
+            # 2. Macro F1: 全ジェスチャーのマクロF1（非ターゲットは単一クラスに統合）
+            y_true_macro = np.array([gesture if gesture in TARGET_GESTURES else 'non_target' for gesture in y_true_str])
+            y_pred_macro = np.array([gesture if gesture in TARGET_GESTURES else 'non_target' for gesture in y_pred_str])
+            
+            macro_f1 = f1_score(y_true_macro, y_pred_macro, average='macro', zero_division='warn')
+            
+        else:
+            # ラベルエンコーダーがない場合は、マルチクラス分類用のF1スコアを計算
+            if verbose:
+                print("Label encoderなし - マルチクラス分類用F1スコアを計算")
+            
+            # マルチクラス分類ではbinaryは使用できないため、microまたはmacroを使用
+            # ここではmacroを使用（各クラスを平等に扱う）
+            binary_f1 = f1_score(y_true, y_pred, average='macro', zero_division='warn')
+            macro_f1 = f1_score(y_true, y_pred, average='macro', zero_division='warn')
+        
+        # 3. 最終スコア = Binary F1 + Macro F1の平均
+        cmi_score = (binary_f1 + macro_f1) / 2.0
+        
+        if verbose:
+            print(f"Binary F1: {binary_f1:.4f}")
+            print(f"Macro F1: {macro_f1:.4f}")
+            print(f"CMI Score: {cmi_score:.4f}")
+            print(f"Test Accuracy: {test_accuracy:.4f}")
+        
+        return cmi_score, binary_f1, macro_f1, test_accuracy
+        
+    except Exception as e:
+        print(f"CMI評価指標計算でエラー: {str(e)}")
+        import traceback
+        traceback.print_exc()
+        return 0.0, 0.0, 0.0, 0.0
+
+
+def get_target_gestures():
+    """ターゲットジェスチャー一覧を取得"""
+    return TARGET_GESTURES.copy()
+
+
+def get_non_target_gestures():
+    """非ターゲットジェスチャー一覧を取得"""
+    return NON_TARGET_GESTURES.copy()
+
+
+def is_target_gesture(gesture_name):
+    """指定されたジェスチャーがターゲットかどうかを判定"""
+    return gesture_name in TARGET_GESTURES
+
+
+def print_gesture_info():
+    """ジェスチャー情報を出力"""
+    print("=== CMI Competition Gesture Information ===")
+    print(f"Target Gestures ({len(TARGET_GESTURES)}):")
+    for i, gesture in enumerate(TARGET_GESTURES, 1):
+        print(f"  {i:2d}. {gesture}")
+    
+    print(f"\nNon-Target Gestures ({len(NON_TARGET_GESTURES)}):")
+    for i, gesture in enumerate(NON_TARGET_GESTURES, 1):
+        print(f"  {i:2d}. {gesture}")
+    
+    print(f"\nTotal: {len(TARGET_GESTURES) + len(NON_TARGET_GESTURES)} gestures")
+
+
+def add_cmi_metrics_to_history(history_dict, y_true, y_pred, label_encoder=None, verbose=False):
+    """
+    学習履歴辞書にCMI評価指標を追加
+    
+    Parameters:
+    -----------
+    history_dict : dict
+        学習履歴辞書
+    y_true : array-like
+        真のラベル
+    y_pred : array-like
+        予測ラベル
+    label_encoder : LabelEncoder, optional
+        ラベルエンコーダー
+    verbose : bool, default=False
+        詳細ログの出力フラグ
+    
+    Returns:
+    --------
+    dict
+        CMI評価指標が追加された学習履歴辞書
+    """
+    try:
+        # CMI評価指標を計算
+        cmi_score, binary_f1, macro_f1, accuracy = calculate_cmi_score(
+            y_pred, y_true, label_encoder, verbose
+        )
+        
+        # 新しい形式の学習履歴に対応
+        if 'training_metrics' in history_dict and 'validation_metrics' in history_dict:
+            # 新しい詳細形式
+            if 'cmi_score' not in history_dict['training_metrics']:
+                history_dict['training_metrics']['cmi_score'] = []
+            if 'binary_f1' not in history_dict['training_metrics']:
+                history_dict['training_metrics']['binary_f1'] = []
+            if 'macro_f1' not in history_dict['training_metrics']:
+                history_dict['training_metrics']['macro_f1'] = []
+            
+            # 検証データのCMI評価指標も追加（同じ値を使用）
+            if 'cmi_score' not in history_dict['validation_metrics']:
+                history_dict['validation_metrics']['cmi_score'] = []
+            if 'binary_f1' not in history_dict['validation_metrics']:
+                history_dict['validation_metrics']['binary_f1'] = []
+            if 'macro_f1' not in history_dict['validation_metrics']:
+                history_dict['validation_metrics']['macro_f1'] = []
+            
+            # 各エポックに同じ値を追加（実際の学習では各エポックで異なる値になる）
+            epochs = len(history_dict['training_metrics']['loss'])
+            for _ in range(epochs):
+                history_dict['training_metrics']['cmi_score'].append(cmi_score)
+                history_dict['training_metrics']['binary_f1'].append(binary_f1)
+                history_dict['training_metrics']['macro_f1'].append(macro_f1)
+                history_dict['validation_metrics']['cmi_score'].append(cmi_score)
+                history_dict['validation_metrics']['binary_f1'].append(binary_f1)
+                history_dict['validation_metrics']['macro_f1'].append(macro_f1)
+        
+        else:
+            # 古い形式
+            if 'cmi_score' not in history_dict:
+                history_dict['cmi_score'] = []
+            if 'binary_f1' not in history_dict:
+                history_dict['binary_f1'] = []
+            if 'macro_f1' not in history_dict:
+                history_dict['macro_f1'] = []
+            
+            epochs = len(history_dict['loss'])
+            for _ in range(epochs):
+                history_dict['cmi_score'].append(cmi_score)
+                history_dict['binary_f1'].append(binary_f1)
+                history_dict['macro_f1'].append(macro_f1)
+        
+        if verbose:
+            print(f"CMI評価指標を学習履歴に追加しました:")
+            print(f"  CMI Score: {cmi_score:.4f}")
+            print(f"  Binary F1: {binary_f1:.4f}")
+            print(f"  Macro F1: {macro_f1:.4f}")
+            print(f"  Accuracy: {accuracy:.4f}")
+        
+        return history_dict
+        
+    except Exception as e:
+        print(f"CMI評価指標の追加でエラー: {str(e)}")
+        return history_dict
+
+
+def create_cmi_metrics_history(y_true, y_pred, label_encoder=None, verbose=False):
+    """
+    CMI評価指標のみの学習履歴を作成
+    
+    Parameters:
+    -----------
+    y_true : array-like
+        真のラベル
+    y_pred : array-like
+        予測ラベル
+    label_encoder : LabelEncoder, optional
+        ラベルエンコーダー
+    verbose : bool, default=False
+        詳細ログの出力フラグ
+    
+    Returns:
+    --------
+    dict
+        CMI評価指標の学習履歴辞書
+    """
+    try:
+        # CMI評価指標を計算
+        cmi_score, binary_f1, macro_f1, accuracy = calculate_cmi_score(
+            y_pred, y_true, label_encoder, verbose
+        )
+        
+        # 学習履歴辞書を作成
+        history_dict = {
+            'training_metrics': {
+                'cmi_score': [cmi_score],
+                'binary_f1': [binary_f1],
+                'macro_f1': [macro_f1],
+                'accuracy': [accuracy]
+            },
+            'validation_metrics': {
+                'cmi_score': [cmi_score],
+                'binary_f1': [binary_f1],
+                'macro_f1': [macro_f1],
+                'accuracy': [accuracy]
+            },
+            'metadata': {
+                'timestamp': '2025-01-01 00:00:00',
+                'model_config': {
+                    'num_classes': len(np.unique(y_true)),
+                    'label_encoder_used': label_encoder is not None
+                }
+            },
+            'summary': {
+                'final_cmi_score': cmi_score,
+                'final_binary_f1': binary_f1,
+                'final_macro_f1': macro_f1,
+                'final_accuracy': accuracy
+            }
+        }
+        
+        if verbose:
+            print(f"CMI評価指標の学習履歴を作成しました:")
+            print(f"  CMI Score: {cmi_score:.4f}")
+            print(f"  Binary F1: {binary_f1:.4f}")
+            print(f"  Macro F1: {macro_f1:.4f}")
+            print(f"  Accuracy: {accuracy:.4f}")
+        
+        return history_dict
+        
+    except Exception as e:
+        print(f"CMI評価指標の学習履歴作成でエラー: {str(e)}")
+        return {}
+
+
+if __name__ == "__main__":
+    # モジュールテスト
+    print_gesture_info()
+    
+    print("\n" + "="*60)
+    print("CMI評価指標モジュールの使用方法")
+    print("="*60)
+    
+    print("""
+【基本的な使用方法】
+
+1. CMI評価指標の計算:
+   from utils.cmi_evaluation import calculate_cmi_score
+   
+   cmi_score, binary_f1, macro_f1, accuracy = calculate_cmi_score(
+       y_pred, y_true, label_encoder, verbose=True
+   )
+
+2. ターゲットジェスチャーの取得:
+   from utils.cmi_evaluation import get_target_gestures, get_non_target_gestures
+   
+   target_gestures = get_target_gestures()
+   non_target_gestures = get_non_target_gestures()
+
+3. ジェスチャーの判定:
+   from utils.cmi_evaluation import is_target_gesture
+   
+   is_target = is_target_gesture("Above ear - pull hair")
+
+4. 学習履歴にCMI評価指標を追加:
+   from utils.cmi_evaluation import add_cmi_metrics_to_history
+   
+   updated_history = add_cmi_metrics_to_history(
+       history_dict, y_true, y_pred, label_encoder, verbose=True
+   )
+
+【CMI評価指標の詳細】
+
+- CMI Score: (Binary F1 + Macro F1) / 2.0
+- Binary F1: ターゲット vs 非ターゲットの2値分類F1スコア
+- Macro F1: 全ジェスチャーのマクロF1スコア（非ターゲットは統合）
+
+【ターゲットジェスチャー（8種類）】
+- Above ear - pull hair
+- Cheek - pinch skin
+- Eyebrow - pull hair
+- Eyelash - pull hair
+- Forehead - pull hairline
+- Forehead - scratch
+- Neck - pinch skin
+- Neck - scratch
+
+【非ターゲットジェスチャー（10種類）】
+- Write name on leg
+- Wave hello
+- Glasses on/off
+- Text on phone
+- Write name in air
+- Feel around in tray and pull out an object
+- Scratch knee/leg skin
+- Pull air toward your face
+- Drink from bottle/cup
+- Pinch knee/leg skin
+
+【関連スクリプト】
+
+学習履歴の可視化:
+python src/scripts/visualize_training_history.py --history path/to/training_history.json
+
+CMI評価指標の追加:
+python src/scripts/add_cmi_metrics_to_history.py --demo --output demo_history.json
+""") 

--- a/submissions/v40_64/src/utils/config_utils.py
+++ b/submissions/v40_64/src/utils/config_utils.py
@@ -1,0 +1,45 @@
+import yaml
+from pathlib import Path
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "config_v2.yaml"
+
+
+def load_config(config_path=None):
+    """Load configuration from specified path or default path.
+    
+    Args:
+        config_path: Path to config file. If None, uses default config.
+        
+    Returns:
+        dict: Configuration dictionary
+    """
+    path = Path(config_path) if config_path else DEFAULT_CONFIG_PATH
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def get_preprocessing_params(config_path=None):
+    """Return preprocessing-related hyperparameters from config.
+    
+    Args:
+        config_path: Path to config file. If None, uses default config.
+        
+    Returns:
+        dict: Preprocessing parameters
+    """
+    cfg = load_config(config_path)
+    return cfg.get("preprocessing", {})
+
+
+def get_cache_dir(cfg: dict | None = None, config_path=None) -> Path:
+    """Return cache directory Path from config.
+    
+    Args:
+        cfg: Configuration dictionary. If None, loads from config_path.
+        config_path: Path to config file. If None, uses default config.
+        
+    Returns:
+        Path: Cache directory path
+    """
+    cfg = cfg or load_config(config_path)
+    return Path(cfg.get("cache_dir", "cache"))

--- a/submissions/v40_64/src/utils/feature_engineering.py
+++ b/submissions/v40_64/src/utils/feature_engineering.py
@@ -1,0 +1,324 @@
+import numpy as np
+import pandas as pd
+import warnings
+from scipy.signal import find_peaks
+
+# ============================================================
+# A. 基本統計量 (mean / std / range / RMS / energy)
+# ============================================================
+### --- Block A Summary ---------------------------------------
+# dims: 56 | 推奨モデル: LightGBM_all / non
+# 広域量的特徴――窓全体の強度・分布を圧縮
+# ------------------------------------------------------------
+def compute_basic_statistics(X_windows: np.ndarray) -> np.ndarray:
+    """Compute Block F statistics per window."""
+    # 外れ値にロバストな統計量を使用
+    means  = np.nanmean(X_windows, axis=1)
+    stds   = np.nanstd(X_windows, axis=1)
+    
+    # パーセンタイルベースの範囲（外れ値にロバスト）
+    q25 = np.nanpercentile(X_windows, 25, axis=1)
+    q75 = np.nanpercentile(X_windows, 75, axis=1)
+    ranges = q75 - q25  # 四分位範囲（IQR）
+    
+    # 外れ値を除外したRMSとエネルギー
+    # 各ウィンドウで外れ値を除外してから計算
+    rms_values = []
+    energy_values = []
+    
+    for i in range(X_windows.shape[0]):
+        window_data = X_windows[i, :, :]
+        
+        # 外れ値を除外（各軸ごと）
+        clean_data = []
+        for axis in range(window_data.shape[1]):
+            axis_data = window_data[:, axis]
+            q1, q99 = np.nanpercentile(axis_data, [1, 99])
+            clean_axis = axis_data[(axis_data >= q1) & (axis_data <= q99)]
+            clean_data.append(clean_axis)
+        
+        # 全軸のデータを結合
+        all_clean_data = np.concatenate(clean_data)
+        
+        if len(all_clean_data) > 0:
+            rms = np.sqrt(np.nanmean(all_clean_data ** 2))
+            energy = np.nansum(all_clean_data ** 2)
+        else:
+            rms = 0.0
+            energy = 0.0
+            
+        rms_values.append(rms)
+        energy_values.append(energy)
+    
+    rms = np.array(rms_values)
+    energy = np.array(energy_values)
+    
+    if X_windows.shape[2] >= 3:
+        mag = np.linalg.norm(X_windows[:, :, :3], axis=2)
+        mag_mean = np.nanmean(mag, axis=1, keepdims=True)
+        mag_std  = np.nanstd(mag, axis=1, keepdims=True)
+        return np.hstack([means, stds, ranges, rms.reshape(-1, 1), energy.reshape(-1, 1), mag_mean, mag_std])
+    else:
+        return np.hstack([means, stds, ranges, rms.reshape(-1, 1), energy.reshape(-1, 1)])
+
+
+# ============================================================
+# B. ピーク & 周期特徴量
+# ============================================================
+### --- Block B Summary ---------------------------------------
+# dims: 18 | 推奨モデル: LightGBM_all / non
+# BFRB の “反復性” をカウントして数値化
+# ------------------------------------------------------------
+
+def extract_peak_features(window: np.ndarray) -> np.ndarray:
+    """Return per‑axis peak counts (Block D)."""
+    return np.array([len(find_peaks(window[:, i])[0]) for i in range(window.shape[1])], dtype=np.float32)
+
+
+def compute_peak_features(X_windows: np.ndarray) -> np.ndarray:
+    """Compute peak features per window."""
+    def extract_peak_features(window):
+        features = []
+        for axis in range(window.shape[1]):
+            signal = window[:, axis]
+            
+            # 外れ値を除外してからピーク検出
+            q1, q99 = np.nanpercentile(signal, [1, 99])
+            clean_signal = signal[(signal >= q1) & (signal <= q99)]
+            
+            if len(clean_signal) > 10:  # 十分なデータがある場合のみ
+                peaks, _ = find_peaks(clean_signal, height=np.nanmean(clean_signal))
+                n_peaks = len(peaks)
+                
+                if n_peaks > 0:
+                    peak_heights = clean_signal[peaks]
+                    avg_peak_height = np.nanmean(peak_heights)
+                    max_peak_height = np.nanmax(peak_heights)
+                    peak_ratio = n_peaks / len(clean_signal)
+                else:
+                    avg_peak_height = 0.0
+                    max_peak_height = 0.0
+                    peak_ratio = 0.0
+            else:
+                n_peaks = 0
+                avg_peak_height = 0.0
+                max_peak_height = 0.0
+                peak_ratio = 0.0
+            
+            features.extend([n_peaks, avg_peak_height, max_peak_height, peak_ratio])
+        return features
+    
+    return np.vstack([extract_peak_features(w) for w in X_windows])
+
+
+# ============================================================
+# C. FFT バンドエネルギー (0.5–20 Hz)
+# ============================================================
+### --- Block C Summary ---------------------------------------
+# dims: 10 | 推奨モデル: LightGBM_all / non
+# 動作リズム・速度の周波数分布
+# ------------------------------------------------------------
+
+def compute_fft_band_energy(X_windows: np.ndarray, fs: float = 50.0, bands=None) -> np.ndarray:
+    """Compute block G FFT band energies."""
+    if bands is None:
+        bands = [(0.5, 2), (2, 5), (5, 10), (10, 20)]
+    n_win, win_len, n_feat = X_windows.shape
+    freqs = np.fft.rfftfreq(win_len, d=1.0 / fs)
+    
+    energies = []
+    for lo, hi in bands:
+        mask = (freqs >= lo) & (freqs < hi)
+        band_energies = []
+        
+        for i in range(n_win):
+            window_energies = []
+            for j in range(n_feat):
+                signal = X_windows[i, :, j]
+                
+                # 外れ値を除外してからFFT計算
+                q1, q99 = np.nanpercentile(signal, [1, 99])
+                clean_signal = signal[(signal >= q1) & (signal <= q99)]
+                
+                if len(clean_signal) > 10:
+                    # パディングして元の長さに戻す
+                    padded_signal = np.zeros(win_len)
+                    padded_signal[:len(clean_signal)] = clean_signal
+                    
+                    power = np.abs(np.fft.rfft(padded_signal)) ** 2
+                    energy = power[mask].sum()
+                else:
+                    energy = 0.0
+                
+                window_energies.append(energy)
+            band_energies.append(window_energies)
+        
+        energies.append(np.array(band_energies))
+    
+    return np.hstack(energies)
+
+
+# ============================================================
+# E. 欠損フラグ (missing sensor flags)
+# ============================================================
+### --- Block E Summary ---------------------------------------
+# dims: 3 | 推奨モデル: すべて
+# 未接続センサを one-hot で明示
+# ------------------------------------------------------------
+def add_missing_sensor_flags(df: pd.DataFrame, sensor_groups: dict) -> pd.DataFrame:
+    """Add boolean missing‑sensor flags per group (Block E)."""
+    for flag, cols in sensor_groups.items():
+        df[flag] = df[cols].isna().all(axis=1)
+    return df
+
+# ============================================================
+# G. TDA Stats (Persistence Image)
+# ============================================================
+### --- Block G Summary ---------------------------------------
+# dims: 8 | 推奨モデル: CNN-GRU concat / LightGBM
+# 位相的周期性を独自にエンコード
+# ------------------------------------------------------------
+def compute_persistence_image_features(X_windows: np.ndarray, dimension:int=1, n_bins:int=20, sigma:float=0.1) -> np.ndarray:
+    """Block J: persistence image features via giotto‑tda."""
+    from gtda.time_series import TakensEmbedding
+    from gtda.homology import VietorisRipsPersistence
+    from gtda.diagrams import PersistenceImage
+
+    emb = TakensEmbedding(time_delay=1, dimension=dimension)
+    vrp = VietorisRipsPersistence(homology_dimensions=[0, 1])
+    pim = PersistenceImage(sigma=sigma, n_bins=n_bins)
+    feats = []
+    for w in X_windows:
+        e = emb.fit_transform(w)
+        d = vrp.fit_transform(e)
+        img = pim.fit_transform(d)
+        feats.append(img.reshape(-1))
+    return np.array(feats, dtype=np.float32)
+
+def compute_persistence_image_features_batch(
+    X_windows: np.ndarray, dimension: int = 2, n_bins: int = 16, sigma: float = 0.1
+) -> np.ndarray:
+    try:
+        from gtda.time_series import TakensEmbedding
+        from gtda.homology import VietorisRipsPersistence
+        from gtda.diagrams import PersistenceImage
+    except ImportError:
+        warnings.warn(
+            "giotto-tda がインストールされていないため、TDA特徴量をスキップします。"
+        )
+        return np.zeros((X_windows.shape[0], 0), dtype=np.float32)
+
+    # デバッグ: TDA処理前のNaN値確認
+    nan_count = np.isnan(X_windows).sum()
+    if nan_count > 0:
+        print(f"⚠️  TDA処理前: NaN値 {nan_count} 個を発見")
+        print(f"   データ形状: {X_windows.shape}")
+        
+        # NaN値を処理
+        X_windows_clean = np.nan_to_num(X_windows, nan=0.0, posinf=1.0, neginf=-1.0)
+        print(f"✅ NaN値を0.0に置換しました")
+    else:
+        X_windows_clean = X_windows
+        print(f"✅ TDA処理前: NaN値なし")
+
+    # 1. Takens埋め込み（全ウィンドウまとめて）
+    emb = TakensEmbedding(time_delay=1, dimension=dimension)
+    embedded = emb.fit_transform(X_windows_clean)  # shape: (n_samples, new_len, dimension)
+
+    # 2. パーシステンス図（全ウィンドウまとめて）
+    vrp = VietorisRipsPersistence(homology_dimensions=[0, 1])
+    diagrams = vrp.fit_transform(embedded)   # shape: (n_samples, n_points, 3)
+
+    # 3. パーシステンス画像（全ウィンドウまとめて）
+    pim = PersistenceImage(sigma=sigma, n_bins=n_bins)
+    images = pim.fit_transform(diagrams)     # shape: (n_samples, n_bins, n_bins)
+
+    # 4. ベクトル化
+    feats = images.reshape(images.shape[0], -1)
+    return feats.astype(np.float32)
+
+# ============================================================
+# H. Auto-Encoder 再構成誤差
+# ============================================================
+### --- Block H Summary ---------------------------------------
+# dims: 4 | 推奨モデル: LightGBM / Binary-GRU (aux)
+# 異常度スコアで BFRB 境界を補強
+# ------------------------------------------------------------
+
+def compute_autoencoder_reconstruction_error(X_windows: np.ndarray, model) -> np.ndarray:
+    """Block K: per‑window MSE reconstruction error from a trained AE."""
+    recon = model.predict(X_windows, verbose=0)
+    return ((X_windows - recon) ** 2).mean(axis=(1, 2), keepdims=True)
+
+
+
+# ============================================================
+# M. Wavelet 周波数特徴 (DWT energies)
+# ============================================================
+
+def compute_wavelet_features(X_windows: np.ndarray, wavelet: str = "db4", level: int = 3) -> np.ndarray:
+    """Block I: discrete wavelet band energies using PyWavelets."""
+    import pywt
+    
+    # NaN値処理
+    nan_count = np.isnan(X_windows).sum()
+    if nan_count > 0:
+        print(f"⚠️  Wavelet処理前: NaN値 {nan_count} 個を発見")
+        X_windows_clean = np.nan_to_num(X_windows, nan=0.0, posinf=1.0, neginf=-1.0)
+        print(f"✅ NaN値を0.0に置換しました")
+    else:
+        X_windows_clean = X_windows
+    
+    feats = []
+    for w in X_windows_clean:
+        ax_feats = []
+        for i in range(w.shape[1]):
+            coeffs = pywt.wavedec(w[:, i], wavelet=wavelet, level=level)
+            ax_feats += [np.sum(c ** 2) for c in coeffs]
+        feats.append(ax_feats)
+    return np.array(feats, dtype=np.float32)
+
+
+# ============================================================
+# N. ToF イベント特徴量
+# ============================================================
+
+def compute_tof_event_features(X_windows: np.ndarray) -> np.ndarray:
+    """Compute simple ToF event features.
+
+    各ウィンドウについて以下を計算します。
+
+    - 最小距離値
+    - 時系列方向の絶対変化率平均
+    """
+
+    window_min = X_windows.min(axis=(1, 2, 3, 4))[:, None]
+    diff = np.diff(X_windows, axis=1)
+    rate = np.mean(np.abs(diff), axis=(1, 2, 3, 4))[:, None]
+    return np.hstack([window_min, rate])
+
+
+# ============================================================
+# O. 温度勾配特徴量
+# ============================================================
+
+def compute_temperature_gradient_features(X_windows: np.ndarray) -> np.ndarray:
+    """Compute temperature gradient based features.
+
+    Parameters
+    ----------
+    X_windows : np.ndarray
+        Shape ``(N, T, C)`` where ``C`` is the数 of thermal sensors.
+
+    Returns
+    -------
+    np.ndarray
+        ``(N, C*3)`` array containing mean/std of first differences and
+        peak（max-min）for each channel.
+    """
+
+    diffs = np.diff(X_windows, axis=1)
+    diff_mean = diffs.mean(axis=1)
+    diff_std = diffs.std(axis=1)
+    peak_width = X_windows.max(axis=1) - X_windows.min(axis=1)
+    return np.hstack([diff_mean, diff_std, peak_width])

--- a/submissions/v40_64/src/utils/imu.py
+++ b/submissions/v40_64/src/utils/imu.py
@@ -1,0 +1,47 @@
+# --- utils/imu.py -------------------------------------------------------
+import numpy as np
+import pandas as pd
+from scipy.spatial.transform import Rotation as R
+
+GRAVITY = 9.80665   # [m/s²]
+
+def quat_normalize_safe(quat: np.ndarray) -> np.ndarray:
+    norm = np.linalg.norm(quat, axis=1, keepdims=True)
+    mask_zero = norm.squeeze() < 1e-6
+    quat[mask_zero] = np.array([1, 0, 0, 0])          # identity
+    quat[~mask_zero] /= norm[~mask_zero]
+    return quat
+
+def accel_world_linear(acc: np.ndarray, quat: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Parameters
+    ----------
+    acc  : (N,3) body-frame raw accelerometer
+    quat : (N,4) quaternion (w,x,y,z) body→world
+
+    Returns
+    -------
+    acc_w  : (N,3) world-frame acceleration
+    lin_acc: (N,3) world-frame linear acceleration (= acc_w – g)
+    """
+    quat = quat_normalize_safe(quat)
+    rot  = R.from_quat(quat[:, [1,2,3,0]])            # (x,y,z,w)
+    acc_w = rot.apply(acc)
+    lin   = acc_w - np.array([0, 0, GRAVITY])
+    return acc_w, lin
+
+def add_world_acc_features(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    前提: 欠損補間 & handedness_correction_v2 後の DataFrame
+    追加列:
+        acc_w_[xyz], lin_acc_[xyz]
+    """
+    df = df.copy()
+    acc  = df[['acc_x','acc_y','acc_z']].to_numpy(dtype=np.float32)
+    quat = quat_normalize_safe(                          # ← ここを変更
+        df[['rot_w','rot_x','rot_y','rot_z']].to_numpy(dtype=np.float32)
+    )
+    acc_w, lin = accel_world_linear(acc, quat)
+    df[['acc_w_x','acc_w_y','acc_w_z']]     = acc_w
+    df[['lin_acc_x','lin_acc_y','lin_acc_z']] = lin
+    return df

--- a/submissions/v40_64/src/utils/io_utils.py
+++ b/submissions/v40_64/src/utils/io_utils.py
@@ -1,0 +1,44 @@
+# src/utils/io_utils.py
+from pathlib import Path
+import pandas as pd, json, hashlib
+
+
+def df_md5(df: pd.DataFrame) -> str:
+    """DataFrame から MD5 ハッシュを計算する"""
+    data = pd.util.hash_pandas_object(df, index=True).values
+    return hashlib.md5(data.tobytes()).hexdigest()
+
+CACHE_DIR   = Path("cache")
+TRAIN_PARQ  = CACHE_DIR / "train_clean.parquet"
+TEST_PARQ   = CACHE_DIR / "test_clean.parquet"
+META_JSON   = CACHE_DIR / "clean_meta.json"
+
+def _md5(path: Path) -> str:
+    return hashlib.md5(path.read_bytes()).hexdigest()
+
+def load_clean_data(raw_train_csv="data/train.csv",
+                    raw_test_csv="data/test.csv",
+                    strict=True):
+    """
+    前処理済み Parquet を読み込む。
+    * strict=True なら MD5 がズレていた場合は例外を投げる
+    """
+    if not TRAIN_PARQ.exists() or not TEST_PARQ.exists():
+        raise FileNotFoundError("cleaned parquet not found – 先に前処理セルを実行してください")
+
+    # MD5 チェック
+    if META_JSON.exists():
+        meta = json.loads(META_JSON.read_text())
+        if strict:
+            if meta["raw_train_md5"] != _md5(Path(raw_train_csv)):
+                raise RuntimeError("raw train CSV has changed – recalc needed")
+            if meta["raw_test_md5"]  != _md5(Path(raw_test_csv)):
+                raise RuntimeError("raw test CSV has changed – recalc needed")
+    else:
+        print("⚠️ meta file not found – skipping MD5 check")
+
+    print("📥 loading cached parquet …", end="", flush=True)
+    train_df = pd.read_parquet(TRAIN_PARQ)
+    test_df  = pd.read_parquet(TEST_PARQ)
+    print("done")
+    return train_df, test_df

--- a/submissions/v40_64/src/utils/kaggle.py
+++ b/submissions/v40_64/src/utils/kaggle.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+
+def is_kaggle():
+    # Kaggle環境ではこの環境変数が必ず存在
+    return "KAGGLE_URL_BASE" in os.environ or Path("/kaggle").exists()
+
+if is_kaggle():
+    # Kaggle環境
+    PROJECT_ROOT = Path("/kaggle/input/cmi-ensemble-v20/")
+    DATA_DIR = Path("/kaggle/input/cmi-detect-behavior-with-sensor-data/")
+    EVAL_MODULE_DIR = Path("/kaggle/input/cmi-detect-behavior-with-sensor-data/")
+else:
+    # ローカル環境
+    PROJECT_ROOT = Path("/mnt/c/Users/ShunK/works/CMI_comp/submissions/ensemble_v1")
+    DATA_DIR = Path("../../data/")
+    EVAL_MODULE_DIR = Path("/mnt/c/Users/ShunK/works/CMI_comp/submissions/ensemble_v1/kaggle_evaluation")
+
+# # 例：使い方
+# print("PROJECT_ROOT:", PROJECT_ROOT)
+# print("DATA_DIR:", DATA_DIR)
+# print("EVAL_MODULE_DIR:", EVAL_MODULE_DIR)

--- a/submissions/v40_64/src/utils/pipeline.py
+++ b/submissions/v40_64/src/utils/pipeline.py
@@ -1,0 +1,897 @@
+# -*- coding: utf-8 -*-
+"""Preprocessing pipeline utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import json
+import pickle
+import logging
+from sklearn.preprocessing import StandardScaler
+
+from .io_utils import df_md5
+
+from pathlib import Path
+import yaml
+
+from .preprocessing import (
+    create_sliding_windows_with_demographics,
+    create_tof_windows_with_info,
+    handedness_correction_v2,
+    augment_handedness_flip,
+    clean_sensor_missing_values,
+    clean_missing_sensor_data_parallel_disk,
+)
+from .feature_engineering import add_missing_sensor_flags
+from .config_utils import load_config, get_cache_dir
+from .tof import tof_to_voxel_tensor
+from .feature_engineering import (
+    compute_basic_statistics,
+    compute_peak_features,
+    compute_fft_band_energy,
+    compute_wavelet_features,
+    compute_persistence_image_features_batch,
+    compute_autoencoder_reconstruction_error,
+    compute_tof_event_features,
+    compute_temperature_gradient_features,
+)
+from .imu import add_world_acc_features
+
+
+logger = logging.getLogger(__name__)
+
+class WindowTensorBuilder:
+    """Generate IMU window tensors with demographics."""
+
+    # def __init__(self, config: dict | None = None) -> None:
+    def __init__(self, config: dict | None = None, mode: str = "train") -> None:
+        self.config = config or load_config()
+        self.mode = mode
+        pp = self.config.get("preprocessing", {})
+        self.window_size = pp.get("window_size", 128)
+        self.stride = pp.get("stride", 64)
+        self.min_len = pp.get("min_sequence_length", 10)
+        self.padding_value = pp.get("padding_value", 0.0)
+        
+        self.sensor_cols = (
+            self.config.get("sensor_acc_cols", [])
+            + self.config.get("sensor_rot_cols", [])
+            + self.config.get("sensor_thm_cols", [])
+        )
+        if pp.get("use_world_acc", False):
+            world_acc_cols = [f"acc_w_{ax}" for ax in "xyz"] + [f"lin_acc_{ax}" for ax in "xyz"]
+            self.sensor_cols.extend(world_acc_cols)
+        
+        self.demographics_cols = self.config.get("demographics_cols", [])
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "windows.pkl"
+        self.meta_file = self.cache_dir / "windows_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(self, df: pd.DataFrame, use_cache: bool = True):
+        logger.info(
+            "Building windows (size=%d, stride=%d, min_len=%d)",
+            self.window_size,
+            self.stride,
+            self.min_len,
+        )
+        md5 = df_md5(df)
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached windows from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        result = create_sliding_windows_with_demographics(
+            df,
+            window_size=self.window_size,
+            stride=self.stride,
+            sensor_cols=self.sensor_cols,
+            demographics_cols=self.demographics_cols,
+            min_sequence_length=self.min_len,
+            padding_value=self.padding_value,
+        )
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info(
+            "Windows shapes: X_sensor=%s, X_demo=%s, y=%s",
+            result[0].shape,
+            result[1].shape,
+            result[2].shape,
+        )
+        return result
+
+
+class TabularFeatureBuilder:
+    """Build tabular features from IMU windows."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        self.sampling_rate = pp.get("sampling_rate", 50.0)
+        self.fft_bands = pp.get("fft_bands", [])
+        self.use_wavelet = pp.get("use_wavelet_features", False)
+        self.use_tda = pp.get("use_tda_features", False)
+        self.use_tof_event = pp.get("use_tof_event_features", False)
+        self.use_temp_grad = pp.get("use_temperature_gradient_features", False)
+        self.wavelet = pp.get("wavelet", "db4")
+        self.wavelet_level = pp.get("wavelet_level", 3)
+        self.tda_dimension = pp.get("tda_dimension", 1)
+        self.tda_bins = pp.get("tda_bins", 20)
+        self.tda_sigma = pp.get("tda_sigma", 0.1)
+        self.window_builder = WindowTensorBuilder(self.config)
+        self.tof_win_builder = ToFWindowBuilder(self.config)
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tabular_features.pkl"
+        self.meta_file = self.cache_dir / "tabular_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(
+        self,
+        df: pd.DataFrame,
+        windows=None,
+        use_cache: bool = True,
+        *,
+        use_wavelet: bool | None = None,
+        use_tda: bool | None = None,
+        use_tof_event: bool | None = None,
+        use_temp_grad: bool | None = None,
+        autoencoder_model=None,
+    ):
+        """Return tabular features for each window.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        windows : tuple or None
+            Precomputed window tensors from :class:`WindowTensorBuilder`.
+        use_cache : bool, default True
+            If True, reuse cached results when available.
+        use_wavelet : bool | None, optional
+            Override config to compute wavelet features.
+        use_tda : bool | None, optional
+            Override config to compute TDA features.
+        use_tof_event : bool | None, optional
+            Override config to compute ToF event features.
+        use_temp_grad : bool | None, optional
+            Override config to compute temperature gradient features.
+        autoencoder_model : optional
+            Pre-trained model used to compute reconstruction errors. The
+            object must implement ``predict`` and return reconstructed
+            windows with the same shape as the input.
+        """
+
+        md5 = df_md5(df)
+        use_wavelet = self.use_wavelet if use_wavelet is None else use_wavelet
+        use_tda = self.use_tda if use_tda is None else use_tda
+        use_tof_event = self.use_tof_event if use_tof_event is None else use_tof_event
+        use_temp_grad = self.use_temp_grad if use_temp_grad is None else use_temp_grad
+        logger.info(
+            "Building tabular features (wavelet=%s, tda=%s, tof_event=%s, temp_grad=%s)",
+            use_wavelet,
+            use_tda,
+            use_tof_event,
+            use_temp_grad,
+        )
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached tabular features from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        if windows is None:
+            X_sensor, X_demo, y, info = self.window_builder.build(df, use_cache=use_cache)
+        else:
+            X_sensor, X_demo, y, info = windows
+            
+        # 外れ値処理はPreprocessorで行うため、ここでは不要
+        X_sensor_clean = X_sensor
+        
+        stats = compute_basic_statistics(X_sensor_clean)
+        peaks = compute_peak_features(X_sensor_clean)
+        fft = compute_fft_band_energy(
+            X_sensor_clean, fs=self.sampling_rate, bands=self.fft_bands
+        )
+
+        # decide whether to compute optional features
+        feats = [stats, peaks, fft]
+        if use_wavelet:
+            wave = compute_wavelet_features(
+                X_sensor_clean, wavelet=self.wavelet, level=self.wavelet_level
+            )
+            feats.append(wave)
+        if use_tda:
+            tda = compute_persistence_image_features_batch(
+                X_sensor_clean,
+                dimension=self.tda_dimension,
+                n_bins=self.tda_bins,
+                sigma=self.tda_sigma,
+            )
+            feats.append(tda)
+        if use_tof_event:
+            X_tof, _ = self.tof_win_builder.build(df, use_cache=use_cache)
+            tof_feat = compute_tof_event_features(X_tof)
+            feats.append(tof_feat)
+        if use_temp_grad:
+            thm_cols = self.config.get("sensor_thm_cols", [])
+            if thm_cols:
+                sensor_config = self.window_builder.sensor_cols
+                idx = [sensor_config.index(c) for c in thm_cols if c in sensor_config]
+                if idx:
+                    temp_feat = compute_temperature_gradient_features(
+                        X_sensor_clean[:, :, idx]
+                    )
+                    feats.append(temp_feat)
+        if autoencoder_model is not None:
+            ae_err = compute_autoencoder_reconstruction_error(
+                X_sensor_clean, autoencoder_model
+            ).reshape(len(X_sensor_clean), -1)
+            feats.append(ae_err)
+            
+        # --- 欠損センサフラグ (per-window mean) ----------------------
+        flag_cols = [
+            c
+            for c in [
+                "missing_flag_imu",
+                "missing_flag_thermal",
+                "missing_flag_tof",
+            ]
+            if c in df.columns
+        ]
+        if flag_cols:
+            grouped = {
+                (s, sid): g[flag_cols].to_numpy(float)
+                for (s, sid), g in df.groupby(["subject", "sequence_id"])
+            }
+            flags = []
+            for m in info:
+                arr = grouped[(m["subject"], m["sequence_id"])]
+                start = m["start_idx"]
+                end = min(m["end_idx"], arr.shape[0])
+                flags.append(arr[start:end].mean(axis=0))
+            flag_array = np.vstack(flags)
+            if flag_array.any():
+                feats.append(flag_array)
+
+        # 最終的なNaN値チェック
+        features = np.hstack(feats + [X_demo])
+        final_nan_count = np.isnan(features).sum()
+        if final_nan_count > 0:
+            logger.warning(f"TabularFeatureBuilder: 最終特徴量にNaN値 {final_nan_count} 個を検出、0.0に置換")
+            features = np.nan_to_num(features, nan=0.0, posinf=1.0, neginf=-1.0)
+        result = (features, y, info)
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info("Tabular features shape %s", result[0].shape)
+        return result
+
+
+class ToFVoxelBuilder:
+    """Convert ToF pixel columns to voxel tensor."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        self.fill_value = pp.get("padding_value", 0.0)
+        depth = pp.get("tof_depth", 5)
+        h = pp.get("tof_height", 8)
+        w = pp.get("tof_width", 8)
+        self.tof_cols = [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)]
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tof_voxel.pkl"
+        self.meta_file = self.cache_dir / "tof_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(self, df: pd.DataFrame, use_cache: bool = True):
+        logger.info("Building ToF voxel tensor")
+        md5 = df_md5(df)
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached ToF voxel from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        sub = df[self.tof_cols] if all(c in df.columns for c in self.tof_cols) else df
+        result = tof_to_voxel_tensor(sub, fill_value=self.fill_value)
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info("ToF voxel shape %s", result.shape)
+        return result
+
+
+class ToFWindowBuilder:
+    """Create sliding windows from ToF voxel tensor."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        self.window_size = pp.get("window_size", 128)
+        self.stride = pp.get("stride", 64)
+        self.min_len = pp.get("min_sequence_length", 10)
+        self.fill_value = pp.get("padding_value", 0.0)
+        depth = pp.get("tof_depth", 5)
+        h = pp.get("tof_height", 8)
+        w = pp.get("tof_width", 8)
+        self.tof_cols = [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)]
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tof_windows.pkl"
+        self.meta_file = self.cache_dir / "tof_windows_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(self, df: pd.DataFrame, use_cache: bool = True):
+        logger.info(
+            "Building ToF windows (size=%d, stride=%d, min_len=%d)",
+            self.window_size,
+            self.stride,
+            self.min_len,
+        )
+        md5 = df_md5(df)
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached ToF windows from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        result = create_tof_windows_with_info(
+            df,
+            window_size=self.window_size,
+            stride=self.stride,
+            tof_cols=self.tof_cols,
+            min_sequence_length=self.min_len,
+            fill_value=self.fill_value,
+        )
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info("ToF windows shape %s", result[0].shape)
+        return result
+
+
+class Preprocessor:
+    """Manage preprocessing statistics and transformations."""
+
+    def __init__(
+        self,
+        config: dict | None = None,
+        *,
+        use_handedness: bool = True,
+        use_basic_cleaning: bool = True,
+        use_interp_cleaning: bool = True,
+        use_world_acc: bool | None = None,
+    ) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        if use_world_acc is None:
+            use_world_acc = pp.get("use_world_acc", False)
+        self.use_handedness_augmentation = pp.get("use_handedness_augmentation", False)
+        self.win_builder = WindowTensorBuilder(self.config)
+        self.tab_builder = TabularFeatureBuilder(self.config)
+        self.tof_builder = ToFVoxelBuilder(self.config)
+        self.tof_win_builder = ToFWindowBuilder(self.config)
+
+        self.sensor_scaler = StandardScaler()
+        self.demo_scaler = StandardScaler()
+        self.tab_scaler = StandardScaler()
+
+        self.use_handedness = use_handedness
+        self.use_basic_cleaning = use_basic_cleaning
+        self.use_interp_cleaning = use_interp_cleaning
+        self.use_world_acc = use_world_acc
+        # handedness augmentation option
+        self.use_handedness_augmentation = bool(self.use_handedness_augmentation)
+
+        pp = self.config.get("preprocessing", {})
+        depth = pp.get("tof_depth", 5)
+        h = pp.get("tof_height", 8)
+        w = pp.get("tof_width", 8)
+        self.sensor_type_groups = {
+            "Accelerometer": list(self.config.get("sensor_acc_cols", [])),
+            "World_Accelerometer": [],  # ワールド座標系専用
+            "Rotation": self.config.get("sensor_rot_cols", []),
+            "Thermal": self.config.get("sensor_thm_cols", []),
+            "ToF_Sensor": [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)],
+        }
+        if self.use_world_acc:
+            self.sensor_type_groups["World_Accelerometer"].extend(
+                [f"acc_w_{ax}" for ax in "xyz"]
+                + [f"lin_acc_{ax}" for ax in "xyz"]
+            )
+
+        interp_path = Path(__file__).resolve().parents[2] / "config" / "interp_params.yaml"
+        if interp_path.exists():
+            with open(interp_path, "r") as f:
+                self.interp_params = yaml.safe_load(f)
+        else:
+            self.interp_params = None
+
+        self._fitted = False
+
+    def _maybe_clean(self, df: pd.DataFrame) -> pd.DataFrame:
+        processed = df.copy()
+        if self.use_handedness:
+            processed = handedness_correction_v2(processed)
+        if self.use_basic_cleaning:
+            processed = clean_sensor_missing_values(
+                processed, self.sensor_type_groups
+            )
+        # 欠損センサフラグを付与
+        flag_groups = {
+            "missing_flag_imu": self.sensor_type_groups.get("Accelerometer", [])
+            + self.sensor_type_groups.get("Rotation", []),
+            "missing_flag_thermal": self.sensor_type_groups.get("Thermal", []),
+            "missing_flag_tof": self.sensor_type_groups.get("ToF_Sensor", []),
+        }
+        processed = add_missing_sensor_flags(processed, flag_groups)
+
+        if self.use_interp_cleaning:
+            base_keep = self.config.get("demographics_cols", [])
+            # Only include columns that exist in the dataframe
+            keep = [col for col in base_keep + ["gesture"] if col in df.columns]
+            keep.extend(flag_groups.keys())
+            processed = clean_missing_sensor_data_parallel_disk(
+                processed,
+                sensor_type_groups=self.sensor_type_groups,
+                interp_params=self.interp_params,
+                keep_cols=keep,
+            )
+        if self.use_world_acc:
+            processed = add_world_acc_features(processed)
+        return processed
+    
+    def _debug_nan_values(self, X_sensor: np.ndarray, stage: str = ""):
+        """NaN値のデバッグ用関数"""
+        if X_sensor is None:
+            return
+            
+        nan_count = np.isnan(X_sensor).sum()
+        if nan_count > 0:
+            print(f"⚠️  {stage}: NaN値 {nan_count} 個を発見")
+            
+            # どの次元にNaNがあるかを確認
+            nan_mask = np.isnan(X_sensor)
+            if nan_mask.any():
+                # ウィンドウごとのNaN数
+                nan_per_window = nan_mask.sum(axis=(1, 2))
+                windows_with_nan = (nan_per_window > 0).sum()
+                print(f"   NaNを含むウィンドウ数: {windows_with_nan}/{len(X_sensor)}")
+                
+                # 特徴量次元ごとのNaN数
+                nan_per_feature = nan_mask.sum(axis=(0, 1))
+                features_with_nan = (nan_per_feature > 0).sum()
+                print(f"   NaNを含む特徴量数: {features_with_nan}/{X_sensor.shape[-1]}")
+                
+                # 各特徴量のNaN数を詳細表示
+                sensor_config = self.win_builder.sensor_cols
+                print("   各特徴量のNaN数:")
+                for i, count in enumerate(nan_per_feature):
+                    if count > 0:
+                        col_name = sensor_config[i] if i < len(sensor_config) else f"feature_{i}"
+                        print(f"     {col_name} (index {i}): {count} 個")
+                
+                # 最初のNaNの位置を表示
+                nan_indices = np.where(nan_mask)
+                if len(nan_indices[0]) > 0:
+                    first_nan = (nan_indices[0][0], nan_indices[1][0], nan_indices[2][0])
+                    col_name = sensor_config[first_nan[2]] if first_nan[2] < len(sensor_config) else f"feature_{first_nan[2]}"
+                    print(f"   最初のNaN位置: ウィンドウ{first_nan[0]}, 時間{first_nan[1]}, {col_name}(index {first_nan[2]})")
+        else:
+            print(f"✅ {stage}: NaN値なし")
+            
+    def _handle_missing_values_by_sensor_type(self, X_sensor: np.ndarray) -> np.ndarray:
+        """センサー別に適切な欠損値処理を行う"""
+        if X_sensor is None:
+            return X_sensor
+            
+        X_clean = X_sensor.copy()
+        # # デバッグ: 処理前のNaN値確認
+        # self._debug_nan_values(X_sensor, "処理前")
+        
+        # センサー別の処理
+        sensor_config = self.win_builder.sensor_cols
+        acc_cols = self.config.get("sensor_acc_cols", [])
+        rot_cols = self.config.get("sensor_rot_cols", [])
+        thm_cols = self.config.get("sensor_thm_cols", [])
+
+        # ワールド座標系加速度の列を追加
+        world_acc_cols = []
+        if self.use_world_acc:
+            # ワールド座標系加速度の列を追加
+            world_acc_cols = self.sensor_type_groups.get("World_Accelerometer", [])
+            
+        acc_indices = []
+        rot_indices = []
+        thm_indices = []
+        world_acc_indices = []
+        
+        # Accelerometer: 0で置換（物理的に正当）
+        if acc_cols:
+            acc_indices = [sensor_config.index(col) for col in acc_cols if col in sensor_config]
+            for idx in acc_indices:
+                if idx < X_clean.shape[-1]:
+                    X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=0.0)
+        
+        # World Accelerometer: 0で置換（加速度と同様）
+        if world_acc_cols:
+            world_acc_indices = [sensor_config.index(col) for col in world_acc_cols if col in sensor_config]
+            for idx in world_acc_indices:
+                if idx < X_clean.shape[-1]:
+                    X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=0.0)
+    
+        # Rotation: 単位クォータニオンで置換
+        if rot_cols:
+            rot_indices = [sensor_config.index(col) for col in rot_cols if col in sensor_config]
+            for i, idx in enumerate(rot_indices):
+                if idx < X_clean.shape[-1]:
+                    if i == 0:  # w成分
+                        X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=1.0)
+                    else:  # x, y, z成分
+                        X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=0.0)
+        
+        # Thermal: 前後の値で補間（簡易版）
+        if thm_cols:
+            thm_indices = [sensor_config.index(col) for col in thm_cols if col in sensor_config]
+            for idx in thm_indices:
+                if idx < X_clean.shape[-1]:
+                    # 時系列方向で補間
+                    for window_idx in range(X_clean.shape[0]):
+                        series = X_clean[window_idx, :, idx]
+                        if np.isnan(series).any():
+                            # 前後の値で補間（空のスライス対策）
+                            if np.isnan(series).all():
+                                # すべてNaNの場合は0で置換
+                                series_clean = np.zeros_like(series)
+                            else:
+                                # 一部NaNの場合は平均で補間
+                                series_clean = np.nan_to_num(series, nan=np.nanmean(series))
+                            X_clean[window_idx, :, idx] = series_clean
+        
+        # その他のセンサー: 0で置換
+        all_processed_indices = set(acc_indices + rot_indices + thm_indices + world_acc_indices)
+        for i in range(X_clean.shape[-1]):
+            if i not in all_processed_indices:
+                X_clean[..., i] = np.nan_to_num(X_clean[..., i], nan=0.0)
+        
+        # # デバッグ: 処理後のNaN値確認
+        # self._debug_nan_values(X_clean, "処理後")
+        return X_clean
+
+    def _handle_outliers_in_sensor_data(self, X_sensor: np.ndarray, percentile_low: float = 0.5, percentile_high: float = 99.5) -> np.ndarray:
+        """センサーデータの外れ値を処理する
+        
+        Parameters
+        ----------
+        X_sensor : np.ndarray
+            センサーデータ
+        percentile_low : float, default 0.5
+            下位パーセンタイル（より厳しい外れ値検出）
+        percentile_high : float, default 99.5
+            上位パーセンタイル（より厳しい外れ値検出）
+        """
+        if X_sensor is None:
+            return X_sensor
+            
+        X_clean = X_sensor.copy()
+        
+        # 各センサー軸ごとに外れ値を処理
+        for axis in range(X_clean.shape[2]):
+            axis_data = X_clean[:, :, axis]
+            
+            # パーセンタイルベースのクリッピング（ウィンザライゼーション）
+            q_low = np.percentile(axis_data, percentile_low)
+            q_high = np.percentile(axis_data, percentile_high)
+            
+            # 外れ値をクリップ
+            axis_data_clipped = np.clip(axis_data, q_low, q_high)
+            X_clean[:, :, axis] = axis_data_clipped
+            
+            # ログ出力（最初の数軸のみ）
+            if axis < 3:
+                outlier_count = np.sum((axis_data < q_low) | (axis_data > q_high))
+                outlier_ratio = outlier_count / axis_data.size * 100
+                if outlier_ratio > 0.1:  # 0.1%以上の場合のみログ
+                    logger.info(f"軸{axis}: 外れ値{outlier_count:,}個 ({outlier_ratio:.2f}%) をクリップ ({percentile_low}%～{percentile_high}%)")
+        
+        return X_clean
+
+    def fit(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> "Preprocessor":
+        """Fit scalers using the provided dataframe.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        use_cache : bool, default True
+            Reuse cached results when available.
+        autoencoder_model : optional
+            Pre-trained model for reconstruction error features. It must
+            implement ``predict`` and return reconstructed windows.
+
+        Returns
+        -------
+        Preprocessor
+            The fitted instance.
+        """
+        logger.info("Fitting Preprocessor")
+        df_proc = self._maybe_clean(df)
+        if self.use_handedness_augmentation:
+            df_proc = augment_handedness_flip(df_proc)
+        windows = self.win_builder.build(df_proc, use_cache=use_cache)
+        X_sensor, X_demo, y, _ = windows
+        
+        # ラベルエンコーディング
+        if "gesture" in df.columns:
+            from sklearn.preprocessing import LabelEncoder
+            self.label_encoder = LabelEncoder()
+            self.label_encoder.fit(df["gesture"])
+            logger.info(f"ラベルエンコーダー作成: {self.label_encoder.classes_}")
+            logger.info(f"ラベルマッピング: {dict(zip(self.label_encoder.classes_, range(len(self.label_encoder.classes_))))}")
+        
+        # センサー別の適切な欠損値処理と外れ値処理
+        X_sensor_clean = self._handle_missing_values_by_sensor_type(X_sensor)
+        X_sensor_clean = self._handle_outliers_in_sensor_data(X_sensor_clean)
+        logger.info("Window tensor shape %s", X_sensor_clean.shape)
+        self.sensor_scaler.fit(X_sensor_clean.reshape(-1, X_sensor_clean.shape[-1]))
+    
+        
+        # 人口統計データの正規化
+        X_demo_clean = np.nan_to_num(X_demo, nan=0.0)
+        self.demo_scaler.fit(X_demo_clean)
+        
+        # 表形式特徴量の正規化
+        processed_windows = (X_sensor_clean, X_demo, y, windows[3])
+        tab, _, _ = self.tab_builder.build(
+            df_proc,
+            windows=processed_windows,
+            use_cache=use_cache,
+            autoencoder_model=autoencoder_model,
+        )
+        # --- クリップ処理を追加 ---
+        tab_clean = np.nan_to_num(tab, nan=0.0)
+        # クリップ閾値をfit時に保存
+        self.tab_clip_low = np.percentile(tab_clean, 0.5, axis=0)
+        self.tab_clip_high = np.percentile(tab_clean, 99.5, axis=0)
+        tab_clean = np.clip(tab_clean, self.tab_clip_low, self.tab_clip_high)
+        self.tab_scaler.fit(tab_clean)
+        logger.info("Tabular features shape %s", tab.shape)
+        
+        # === ToF正規化パラメータ計算 ===
+        tof_tensor = self.tof_builder.build(df_proc, use_cache=use_cache)
+        # 負の値を欠損値として扱う（-1だけでなく、負の値全体）
+        mask = (tof_tensor > 0)
+        if mask.sum() > 0:
+            self.tof_mean = float(tof_tensor[mask].mean())
+            self.tof_std = float(tof_tensor[mask].std())
+            logger.info(f"ToF mean: {self.tof_mean:.3f}, std: {self.tof_std:.3f} (有効値: {mask.sum():,}個)")
+        else:
+            self.tof_mean = 0.0
+            self.tof_std = 1.0
+            logger.warning("ToF: 有効な正の値が見つかりませんでした")
+
+        # ToF Windowsの正規化パラメータも計算
+        tof_windows_fit, _ = self.tof_win_builder.build(df_proc, use_cache=use_cache)
+        mask_win_fit = (tof_windows_fit > 0)
+        if mask_win_fit.sum() > 0:
+            self.tof_windows_mean = float(tof_windows_fit[mask_win_fit].mean())
+            self.tof_windows_std = float(tof_windows_fit[mask_win_fit].std())
+            logger.info(f"ToF Windows mean: {self.tof_windows_mean:.3f}, std: {self.tof_windows_std:.3f} (有効値: {mask_win_fit.sum():,}個)")
+        else:
+            self.tof_windows_mean = 0.0
+            self.tof_windows_std = 1.0
+            logger.warning("ToF Windows: 有効な正の値が見つかりませんでした")
+
+        self._fitted = True
+        return self
+
+    def transform(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> dict:
+        """Transform dataframe using fitted scalers.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        use_cache : bool, default True
+            Reuse cached results when available.
+        autoencoder_model : optional
+            Pre-trained model used for reconstruction error features. The
+            object must provide ``predict`` returning reconstructed windows.
+
+        Returns
+        -------
+        dict
+            Dictionary containing processed arrays.
+        """
+        if not self._fitted:
+            raise RuntimeError("Preprocessor is not fitted")
+        logger.info("Transforming dataframe of shape %s", df.shape)
+        df_proc = self._maybe_clean(df)
+        if self.use_handedness_augmentation:
+            df_proc = augment_handedness_flip(df_proc)
+        windows = self.win_builder.build(df_proc, use_cache=use_cache)
+        X_sensor, X_demo, y, info = windows
+        
+        # センサー別の適切な欠損値処理、外れ値処理、正規化
+        logger.info("Window tensor shape %s", X_sensor.shape)
+        X_sensor_clean = self._handle_missing_values_by_sensor_type(X_sensor)
+        X_sensor_clean = self._handle_outliers_in_sensor_data(X_sensor_clean)
+        X_sensor_normalized = self.sensor_scaler.transform(
+            X_sensor_clean.reshape(-1, X_sensor_clean.shape[-1])
+        ).reshape(X_sensor_clean.shape)
+        
+        # 人口統計データの正規化
+        X_demo_clean = np.nan_to_num(X_demo, nan=0.0)
+        X_demo_normalized = self.demo_scaler.transform(X_demo_clean)
+        
+        # 表形式特徴量の正規化
+        processed_windows = (X_sensor_clean, X_demo, y, info)
+        tab, _, _ = self.tab_builder.build(
+            df_proc,
+            windows=processed_windows,
+            use_cache=use_cache,
+            autoencoder_model=autoencoder_model,
+        )
+        # 欠損値処理と外れ値処理を追加してfit時とtransform時で一貫性を保つ
+        tab_clean = np.nan_to_num(tab, nan=0.0)
+        # --- クリップ処理をfitで保存した閾値で適用 ---
+        if hasattr(self, "tab_clip_low") and hasattr(self, "tab_clip_high"):
+            tab_clean = np.clip(tab_clean, self.tab_clip_low, self.tab_clip_high)
+        tab_normalized = self.tab_scaler.transform(tab_clean)
+        
+        # === ToF正規化 ===
+        tof_tensor = self.tof_builder.build(df_proc, use_cache=use_cache)
+        # 負の値を欠損値として扱う（-1だけでなく、負の値全体）
+        mask = (tof_tensor > 0)
+        tof_tensor_norm = np.zeros_like(tof_tensor)
+        if hasattr(self, "tof_mean") and hasattr(self, "tof_std") and self.tof_std > 0:
+            tof_tensor_norm[mask] = (tof_tensor[mask] - self.tof_mean) / self.tof_std
+            tof_tensor_norm[~mask] = -1  # 欠損値を-1で埋め戻す
+            logger.info(f"ToF正規化完了: 有効値{mask.sum():,}個, 欠損値{(~mask).sum():,}個")
+        else:
+            tof_tensor_norm = tof_tensor  # 正規化できない場合はそのまま
+            logger.warning("ToF: 正規化パラメータが利用できません")
+            
+        tof_windows, _ = self.tof_win_builder.build(df_proc, use_cache=use_cache)
+        mask_win = (tof_windows > 0)
+        tof_windows_norm = np.zeros_like(tof_windows)
+        if hasattr(self, "tof_windows_mean") and hasattr(self, "tof_windows_std") and self.tof_windows_std > 0:
+            tof_windows_norm[mask_win] = (tof_windows[mask_win] - self.tof_windows_mean) / self.tof_windows_std
+            tof_windows_norm[~mask_win] = -1  # 欠損値を-1で埋め戻す
+            logger.info(f"ToF Windows正規化完了: 有効値{mask_win.sum():,}個, 欠損値{(~mask_win).sum():,}個")
+        else:
+            tof_windows_norm = tof_windows
+            logger.warning("ToF Windows: 正規化パラメータが利用できません")
+            
+        logger.info(
+            "Output shapes: windows=%s, demographics=%s, tabular=%s, tof=%s, tof_win=%s",
+            X_sensor.shape,
+            X_demo.shape,
+            tab.shape,
+            tof_tensor.shape,
+            tof_windows.shape,
+        )
+        # ラベルエンコーディングの適用
+        if hasattr(self, "label_encoder") and y is not None:
+            # testデータかどうかを判定（-1のみの場合はtestデータ）
+            if len(np.unique(y)) == 1 and y[0] == -1:
+                logger.info("testデータのため、ラベルエンコーディングをスキップ")
+                y_encoded = y  # -1のまま保持
+            else:
+                # trainデータの場合のみラベルエンコーディングを適用
+                y_encoded = self.label_encoder.transform(y)
+                logger.info(f"ラベルエンコーディング適用: {np.unique(y_encoded)}")
+        else:
+            y_encoded = y
+        
+        return {
+            "windows": X_sensor_normalized,
+            "demographics": X_demo_normalized,
+            "tabular": tab_normalized,
+            "tof_voxel": tof_tensor_norm,  # 正規化済みデータを使用
+            "tof_windows": tof_windows_norm,  # 正規化済みデータを使用
+            "labels": y_encoded,
+            "info": info,
+        }
+
+    def fit_transform(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> dict:
+        self.fit(df, use_cache=use_cache, autoencoder_model=autoencoder_model)
+        return self.transform(
+            df, use_cache=use_cache, autoencoder_model=autoencoder_model
+        )
+        """Fit the preprocessor and transform the data in one call.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        use_cache : bool, default True
+            Reuse cached results when available.
+        autoencoder_model : optional
+            Pre-trained model with ``predict`` returning reconstructed
+            windows.
+
+        Returns
+        -------
+        dict
+            Dictionary of processed arrays.
+        """
+
+        self.fit(df, use_cache=use_cache, autoencoder_model=autoencoder_model)
+        return self.transform(df, use_cache=use_cache, autoencoder_model=autoencoder_model)
+
+    def save(self, path: Path) -> None:
+        """Save scaler objects and settings to a pickle file."""
+        logger.info("Saving Preprocessor to %s", path)
+        data = {
+            "config": self.config,
+            "use_handedness": self.use_handedness,
+            "use_basic_cleaning": self.use_basic_cleaning,
+            "use_interp_cleaning": self.use_interp_cleaning,
+            "use_world_acc": self.use_world_acc,
+            "use_handedness_augmentation": self.use_handedness_augmentation,
+            "sensor_scaler": self.sensor_scaler,
+            "demo_scaler": self.demo_scaler,
+            "tab_scaler": self.tab_scaler,
+            "_fitted": self._fitted,
+            "tof_mean": getattr(self, "tof_mean", None),
+            "tof_std": getattr(self, "tof_std", None),
+            "tof_windows_mean": getattr(self, "tof_windows_mean", None),
+            "tof_windows_std": getattr(self, "tof_windows_std", None),
+            "label_encoder": getattr(self, "label_encoder", None),
+        }
+        with open(path, "wb") as f:
+            pickle.dump(data, f)
+
+    @classmethod
+    def load(cls, path: Path) -> "Preprocessor":
+        """Load scalers and settings from a pickle file."""
+        logger.info("Loading Preprocessor from %s", path)
+        with open(path, "rb") as f:
+            data = pickle.load(f)
+        obj = cls(
+            data.get("config"),
+            use_handedness=data.get("use_handedness", True),
+            use_basic_cleaning=data.get("use_basic_cleaning", True),
+            use_interp_cleaning=data.get("use_interp_cleaning", True),
+            use_world_acc=data.get("use_world_acc"),
+        )
+        obj.sensor_scaler = data["sensor_scaler"]
+        obj.demo_scaler = data["demo_scaler"]
+        obj.tab_scaler = data["tab_scaler"]
+        obj._fitted = data.get("_fitted", False)
+        obj.tof_mean = data.get("tof_mean", None)
+        obj.tof_std = data.get("tof_std", None)
+        obj.tof_windows_mean = data.get("tof_windows_mean", None)
+        obj.tof_windows_std = data.get("tof_windows_std", None)
+        obj.label_encoder = data.get("label_encoder", None)
+        obj.use_handedness_augmentation = data.get("use_handedness_augmentation", False)
+        return obj

--- a/submissions/v40_64/src/utils/preprocessing.py
+++ b/submissions/v40_64/src/utils/preprocessing.py
@@ -1,0 +1,476 @@
+"""
+Preprocessing utilities for the CMI competition (commented version).
+
+"""
+
+import numpy as np
+import pandas as pd
+from .tof import tof_to_voxel_tensor
+
+
+# ============================================================
+# L. 利き手反転正規化 (Y/Z flip for left‑handed)
+# ============================================================
+from typing import Sequence
+
+def handedness_correction_v2(
+    df: pd.DataFrame,
+    *,
+    imu_prefixes: Sequence[str] = ("acc", "gyro", "rot", "mag"),
+    apply_tof_mirror: bool = True,
+) -> pd.DataFrame:
+    """
+    左利き (handedness==0) サンプルを右利き座標系に正規化する。
+
+    1. IMU (acc/gyro/rot/mag) の Y・Z 軸を符号反転
+       - rot_w は反転しない
+    2. ToF センサは左右ピクセルを鏡像ミラー (値はそのまま)
+       - 値の符号反転は行わない
+    """
+    df = df.copy()
+    left = df["handedness"] == 0
+
+    # --- 1) IMU の Y/Z 反転 ------------------------------------------
+    axis_sign = {"x": 1, "y": -1, "z": -1, "w": 1}       # rot_w は 1
+    for pre in imu_prefixes:
+        axes = ("w", "x", "y", "z") if pre == "rot" else ("x", "y", "z")
+        for ax in axes:
+            col = f"{pre}_{ax}"
+            if col in df.columns:
+                df.loc[left, col] *= axis_sign[ax]
+
+    # --- 2) ToF 水平ミラー -------------------------------------------
+    if apply_tof_mirror:
+        tof_cols = [c for c in df.columns if c.startswith("tof_")]
+        if tof_cols:  # mirror_tof_rows は既存関数を流用
+            df.loc[left, tof_cols] = mirror_tof_rows(df.loc[left, :], tof_cols)
+
+    return df
+
+
+def augment_handedness_flip(
+    df: pd.DataFrame,
+    *,
+    imu_prefixes: Sequence[str] = ("acc", "gyro", "rot", "mag"),
+    apply_tof_mirror: bool = True,
+) -> pd.DataFrame:
+    """左右反転したデータを追加して返すデータ拡張用関数"""
+    df_flip = df.copy()
+
+    # IMU の Y/Z 軸を反転させる
+    for pre in imu_prefixes:
+        axes = ("w", "x", "y", "z") if pre == "rot" else ("x", "y", "z")
+        for ax in axes:
+            col = f"{pre}_{ax}"
+            if col in df_flip.columns and ax in {"y", "z"}:
+                df_flip[col] = -df_flip[col]
+
+    # ToF の左右ピクセルを鏡像ミラー
+    if apply_tof_mirror:
+        tof_cols = [c for c in df_flip.columns if c.startswith("tof_")]
+        if tof_cols:
+            df_flip = mirror_tof_rows(df_flip, tof_cols)
+
+    # 利き手ラベルを反転
+    if "handedness" in df_flip.columns:
+        df_flip["handedness"] = 1 - df_flip["handedness"]
+
+    # 既存の subject/sequence_id と被らないようオフセット
+    if "subject" in df_flip.columns:
+        df_flip["subject"] = df_flip["subject"] + df["subject"].max() + 1
+    if "sequence_id" in df_flip.columns:
+        df_flip["sequence_id"] = df_flip["sequence_id"] + df["sequence_id"].max() + 1
+
+    # 元データと結合
+    return pd.concat([df, df_flip], ignore_index=True)
+
+
+import re
+# ── 1. ToF の水平ミラー（左右反転）関数 ─────────────────────────
+def mirror_tof_rows(df: pd.DataFrame, tof_cols: list[str]) -> pd.DataFrame:
+    """
+    各行の ToF ピクセル(8×8) を水平ミラーします。
+    df[tof_cols] の形状は (N, 64×D) を想定。
+    """
+    pattern = re.compile(r"tof_(\d+)_v(\d+)")
+    # センサIDごとのグループを取得
+    sensor_ids = sorted({int(pattern.match(c).group(1)) for c in tof_cols})
+    out = df.copy()
+    for sid in sensor_ids:
+        # 当該センサの 64 列を時系列順に並べて (N, H, W) にreshape
+        cols = [f"tof_{sid}_v{i}" for i in range(64)]
+        arr = df[cols].to_numpy().reshape(-1, 8, 8)
+        # W方向を反転
+        flipped = arr[:, :, ::-1]
+        # 元に戻して DataFrame に代入
+        out.loc[:, cols] = flipped.reshape(-1, 64)
+    return out
+
+
+# ============================================================
+# Utility : Missing-value Cleaning
+# =============================
+
+# =========================================================
+# D) センサータイプごとに欠損値を適切に処理する関数
+# =========================================================
+
+def clean_sensor_missing_values(
+    df: pd.DataFrame,
+    sensor_type_groups: dict,
+    acc_clip: tuple = (-40.0, 40.0),
+) -> pd.DataFrame:
+    """
+    センサータイプごとに欠損値を適切に処理する関数（調査結果に基づく）
+    
+    ── Rules (調査結果ベース) ────────────────────────────────
+      • Accelerometer :   0 / −1 は正当値 → 極端値 |value|>acc_clip を NaN
+      • Rotation      :   NaN のみ欠損値
+      • ToF_Sensor    :   NaN, -1 および -1 未満 → 欠損値 (NaN 化)
+      • Thermal       :   NaN のみ欠損値
+    ─────────────────────────────────────────────────────────
+    """
+    df = df.copy()
+
+    # ------------------ 1) Accelerometer ------------------
+    acc_cols = sensor_type_groups.get("Accelerometer", [])
+    if acc_cols:
+        # |value| > clip 上限を欠測とみなす
+        df[acc_cols] = df[acc_cols].where(
+            df[acc_cols].abs().le(acc_clip[1]), np.nan
+        )
+
+    # ------------------ 2) ToF_Sensor ---------------------
+    tof_cols = sensor_type_groups.get("ToF_Sensor", [])
+    if tof_cols:
+        # a) 上限超え (255 以上) は NaN
+        df[tof_cols] = df[tof_cols].where(df[tof_cols] <= 254, np.nan)
+        # b) -2 以下も NaN （ハードエラー）
+        df[tof_cols] = df[tof_cols].where(df[tof_cols] >= -1, np.nan)
+        # ※ -1 は “反射なし” → そのまま残す
+
+    # ------------------ 3) Rotation / Thermal -------------
+    # 既定では NaN のみ欠測 → 追加処理不要
+    return df
+
+
+# =========================================================
+# A) 補間パラメータ（調査結果を反映）
+# =========================================================
+# 外部ファイルで定義
+
+# =========================================================
+# B) クォータニオン SLERP と ToF 用補間関数
+# =========================================================
+from scipy.spatial.transform import Rotation, Slerp
+import numpy as np
+import pandas as pd
+
+def _interpolate_quaternion_block(df, cols, time_col, limit):
+    q = df[cols].to_numpy(float)
+
+    # 0-norm → 欠測扱い
+    norm = np.linalg.norm(q, axis=1, keepdims=True)
+    q[norm.squeeze() < 1e-6] = np.nan
+
+    t = df[time_col].to_numpy()
+    mask_nan = np.isnan(q).any(axis=1)
+
+    i = 0
+    while i < len(q):
+        if mask_nan[i]:
+            # --- 欠測 run の [start+1 : end-1] を補間 -----------------
+            start = i - 1               # start は常に定義される
+            j = i
+            while j < len(q) and mask_nan[j]:
+                j += 1
+            end = j                      # first non-NaN idx or len(q)
+            run_len = end - start - 1
+            if start >= 0 and end < len(q) and run_len <= limit:
+                key_times = np.array([t[start], t[end]])
+                key_rots  = Rotation.from_quat(q[[start, end]])
+                slerp = Slerp(key_times, key_rots)
+                q[start+1:end] = slerp(t[start+1:end]).as_quat()
+            i = end                      # ← 欠測 run の次フレームへ
+        else:
+            i += 1                       # 欠測でない→次へ
+
+    # 補間後に正規化
+    valid = ~np.isnan(q).any(axis=1)
+    q[valid] /= np.linalg.norm(q[valid], axis=1, keepdims=True)
+    # まだ NaN があれば identity に
+    q[~valid] = np.array([1,0,0,0])
+
+    return pd.DataFrame(q, columns=cols, index=df.index)
+
+
+
+def _interpolate_tof_block(df, cols, limit, fill_value=-1):
+    """-1 は反射なし → 一時 NaN → 短ラン補間 → -1 に戻す"""
+    blk = df[cols].replace(fill_value, np.nan)
+    blk = blk.interpolate(method="linear",
+                          limit=limit,
+                          limit_direction="both")
+    return blk.fillna(fill_value)
+
+# =========================================================
+# C) 並列 & ディスク結合版クリーニング
+# =========================================================
+from joblib import Parallel, delayed
+from tqdm.auto import tqdm
+import tempfile, shutil
+from pathlib import Path
+
+def clean_missing_sensor_data_parallel_disk(
+    df: pd.DataFrame,
+    sensor_type_groups: dict[str, list[str]],
+    group_cols=("subject", "sequence_id"),
+    time_col: str = "sequence_counter",
+    interp_params: dict | None = None,
+    n_jobs: int = -1,
+    tmp_parent: str | Path = "/tmp/tmp_clean_chunks",
+    keep_tmp: bool = False,
+    keep_cols: list[str] | None = None,        # ★NEW
+) -> pd.DataFrame:
+
+    keep_cols = list(keep_cols or [])
+    base_cols = list(group_cols) + [time_col] + keep_cols
+    
+    # 0) デフォルト
+    default_params = {
+        "Accelerometer": {"method": "linear", "limit": 3},
+        "Rotation":      {"method": "slerp",  "limit": 120},
+        "ToF_Sensor":    {"method": "linear", "limit": 4, "fill_value": -1},
+        "Thermal":       {"method": "linear", "limit": 120},
+    }
+    interp_params = interp_params or default_params
+
+    # 1) ソート
+    df = df.sort_values(list(group_cols) + [time_col]).copy()
+
+    # 2) 一時ディレクトリ
+    tmp_root = Path(tmp_parent); tmp_root.mkdir(exist_ok=True)
+    tmp_dir = tempfile.mkdtemp(dir=tmp_root)
+
+    # 3) 各グループを並列補間 → parquet 保存
+    def _interpolate_and_dump(key, g,
+                            sensor_type_groups, interp_params,
+                            time_col, tmp_dir):
+
+        # --- 欠測補間 -------------------------------------------------
+        for s_type, cols in sensor_type_groups.items():
+            # World_Accelerometerの場合はスキップ
+            if s_type == "World_Accelerometer":
+                continue
+                
+            params = interp_params[s_type]
+            method = params.get("method")
+            limit  = params.get("limit", 3)
+
+            if method is None:
+                continue
+            if s_type == "Rotation":
+                g[cols] = _interpolate_quaternion_block(
+                    g, cols, time_col, limit)
+            elif s_type == "ToF_Sensor":
+                g[cols] = _interpolate_tof_block(
+                    g, cols, limit, params.get("fill_value", -1))
+            else:  # Accelerometer / Thermal
+                g[cols] = g[cols].interpolate(
+                    method=method,
+                    limit=limit,
+                    limit_direction="both"
+                )
+        # -------------------------------------------------------------
+
+        # Parquet 出力
+        subject, seq_id = key
+        # ❶ 保存したい列を計算（存在するカラムのみ）
+        all_cols = base_cols + sum(sensor_type_groups.values(), [])
+        save_cols = list(dict.fromkeys(all_cols))
+        # DataFrameに存在するカラムのみをフィルタ
+        save_cols = [col for col in save_cols if col in g.columns]
+
+
+        # ❷ サブセットを取ってから Parquet 書き出し
+        out_path = Path(tmp_dir) / f"{subject}_{seq_id}.parquet"
+        g.loc[:, save_cols].to_parquet(out_path)   # ← columns 引数を削除
+        return out_path
+
+    # ① (key, grp) を保持
+    groups = [(key, grp) for key, grp in df.groupby(list(group_cols), sort=False)]
+
+    # ② key を _interpolate_and_dump に渡す
+    paths = Parallel(n_jobs=n_jobs, backend="loky")(
+        delayed(_interpolate_and_dump)(
+            key, grp,              # ← 変更
+            sensor_type_groups,
+            interp_params,
+            time_col,
+            tmp_dir
+        )
+        for key, grp in tqdm(groups, desc="interp", unit="seq")
+    )
+    # 4) 結合
+    cleaned = pd.concat(
+        (pd.read_parquet(p) for p in tqdm(paths, desc="concat")),
+        ignore_index=True          # ← sort_index 不要に
+    )
+
+    if not keep_tmp:
+        # 削除はバックグラウンドでも可
+        import threading, shutil
+        threading.Thread(target=shutil.rmtree,
+                        args=(tmp_dir,),
+                        kwargs=dict(ignore_errors=True),
+                        daemon=True).start()
+
+    return cleaned 
+
+# ============================================================
+# I. 合成 Tabular (= A–H)
+# ============================================================
+### --- Block I Summary ---------------------------------------
+# dims: 120 | 推奨モデル: LightGBM_all / CatBoost
+# 木モデル用に Tabular 特徴を統合
+# ------------------------------------------------------------
+# （統合処理は学習パイプライン側で実施）
+
+
+# ============================================================
+# J. IMU Sliding Window Tensor
+# ============================================================
+### --- Block J Summary ---------------------------------------
+# dims: 7×256 = 1 792 | 推奨モデル: Binary-GRU / CNN-GRU
+# 局所パターン＋長期文脈を時系列テンソルで捕捉
+# ------------------------------------------------------------
+def create_sliding_windows_with_demographics(
+    df: pd.DataFrame,
+    window_size: int,
+    stride: int,
+    sensor_cols: list,
+    demographics_cols: list,
+    min_sequence_length: int = 10,
+    padding_value: float = 0.0,
+):
+    """Block B: generate fixed‑length windows and attach static demographics."""
+    X_sensor_windows, X_demographics_windows, y_windows, info = [], [], [], []
+
+    for (subject, seq_id), g in df.groupby(["subject", "sequence_id"]):
+        seq_len = len(g)
+        if seq_len < min_sequence_length:
+            continue
+        sensor = g[sensor_cols].values
+        demo = g[demographics_cols].iloc[0].values
+        
+        # Handle case where gesture column doesn't exist (e.g., test data)
+        if "gesture" in g.columns:
+            gesture = g["gesture"].iloc[0]
+        else:
+            # For test data, we don't have gesture labels
+            # We'll use a placeholder value that won't affect the model training
+            gesture = -1  # Use -1 as placeholder for test data
+        
+        need_pad = seq_len < window_size
+        if need_pad:
+            pad = np.full((window_size - seq_len, len(sensor_cols)), padding_value)
+            sensor = np.vstack([sensor, pad])
+        for s in range(0, len(sensor) - window_size + 1, stride):
+            e = s + window_size
+            X_sensor_windows.append(sensor[s:e])
+            X_demographics_windows.append(demo)
+            y_windows.append(gesture)
+            info.append({"subject": subject, "sequence_id": seq_id, "start_idx": s, "end_idx": e, "padded": need_pad})
+
+    return (
+        np.asarray(X_sensor_windows, dtype=np.float32),
+        np.asarray(X_demographics_windows, dtype=np.float32),
+        np.asarray(y_windows),
+        info,
+    )
+
+
+def create_tof_windows_with_info(
+    df: pd.DataFrame,
+    window_size: int,
+    stride: int,
+    tof_cols: list,
+    min_sequence_length: int = 10,
+    fill_value: float = 0.0,
+) -> tuple[np.ndarray, list[dict]]:
+    """Generate sliding windows for ToF voxel tensor with metadata.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe containing ToF pixel columns.
+    window_size : int
+        Length of each window.
+    stride : int
+        Step size between windows.
+    tof_cols : list
+        Column names of ToF pixels to be used.
+    min_sequence_length : int, default 10
+        Minimum sequence length to consider a sequence.
+    fill_value : float, default 0.0
+        Padding value for sequences shorter than ``window_size``.
+
+    Returns
+    -------
+    tuple[np.ndarray, list[dict]]
+        ``windows`` with shape ``(N, window_size, depth, H, W)`` and
+        ``info`` containing metadata for each window.
+    """
+
+    X_windows, info = [], []
+
+    for (subject, seq_id), g in df.groupby(["subject", "sequence_id"]):
+        seq_len = len(g)
+        if seq_len < min_sequence_length:
+            continue
+
+        tensor = tof_to_voxel_tensor(g[tof_cols], fill_value=fill_value)
+        need_pad = seq_len < window_size
+        if need_pad:
+            pad = np.full(
+                (window_size - seq_len,) + tensor.shape[1:],
+                fill_value,
+                dtype=tensor.dtype,
+            )
+            tensor = np.concatenate([tensor, pad], axis=0)
+
+        for s in range(0, len(tensor) - window_size + 1, stride):
+            e = s + window_size
+            X_windows.append(tensor[s:e])
+            info.append(
+                {
+                    "subject": subject,
+                    "sequence_id": seq_id,
+                    "start_idx": s,
+                    "end_idx": e,
+                    "padded": need_pad,
+                }
+            )
+
+    return np.asarray(X_windows, dtype=np.float32), info
+
+
+
+
+# ============================================================
+# C. 正規化ユーティリティ (sensor / tabular)
+# ============================================================
+
+def normalize_sensor_data(X: np.ndarray):
+    """Block C‑1: z‑score normalisation for sensor windows."""
+    scaler = StandardScaler()
+    n, t, f = X.shape
+    X_flat = np.nan_to_num(X.reshape(-1, f), nan=0.0)
+    X_norm = scaler.fit_transform(X_flat).reshape(n, t, f)
+    return X_norm, scaler
+
+
+def normalize_tabular_data(X: np.ndarray):
+    """Block C‑2: z‑score normalisation for demographics/tabular."""
+    scaler = StandardScaler()
+    return scaler.fit_transform(X), scaler

--- a/submissions/v40_64/src/utils/tof.py
+++ b/submissions/v40_64/src/utils/tof.py
@@ -1,0 +1,36 @@
+
+"""ToF (Time-of-Flight) related utilities."""
+
+import numpy as np
+import pandas as pd
+
+
+# ============================================================
+# K. ToF 3D Voxel Tensor
+# ============================================================
+### --- Block K Summary ---------------------------------------
+# dims: 20 480 | 推奨モデル: ToF-3D-CNN
+# 顔・対象物との空間的接近パターンを 3D で表現
+# ------------------------------------------------------------
+
+def tof_to_voxel_tensor(df: pd.DataFrame, fill_value: float = -1.0, prefix: str = "tof_") -> np.ndarray:
+    """Block L: convert ToF pixel columns → (T, depth, H, W) tensor."""
+    import re
+    pat = re.compile(fr"^{prefix}(\d+)_v(\d+)$")
+    matches = [(c, pat.match(c)) for c in df.columns]
+    sensors = sorted({int(m.group(1)) for _, m in matches if m})
+    idxs = [int(m.group(2)) for _, m in matches if m]
+    if not sensors:
+        raise ValueError("No ToF columns found")
+    W = H = int(np.sqrt(max(idxs) + 1))
+    T = len(df)
+    D = len(sensors)
+    tensor = np.full((T, D, H, W), fill_value, dtype=np.float32)
+    for d, sn in enumerate(sensors):
+        for idx in range(H * W):
+            col = f"{prefix}{sn}_v{idx}"
+            if col in df.columns:
+                vals = df[col].replace(-1, fill_value).to_numpy(dtype=np.float32)
+                r, c = divmod(idx, W)
+                tensor[:, d, r, c] = vals
+    return tensor

--- a/submissions/v40_64and128/cmi-2025-demo-submission.ipynb
+++ b/submissions/v40_64and128/cmi-2025-demo-submission.ipynb
@@ -1,0 +1,362 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "# CMI Behavior Detection with Multimodal V40 (ws64 & ws128 ensemble)\n",
+        "\n",
+        "This notebook uses an ensemble of two 5-fold multimodal models (window size 64 and 128) for gesture recognition. The predictions from both model sets are averaged to produce the final result."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2025-07-22 09:02:38.164453: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+            "2025-07-22 09:02:39.573434: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+            "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+            "E0000 00:00:1753142560.060496  608809 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+            "E0000 00:00:1753142560.185875  608809 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+            "W0000 00:00:1753142561.290751  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1753142561.290781  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1753142561.290782  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1753142561.290783  608809 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "2025-07-22 09:02:41.406674: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+            "To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+            "INFO:src.inference_pipeline:Loading configurations...\n",
+            "INFO:src.inference_pipeline:Loading preprocessors...\n",
+            "INFO:utils.pipeline:Loading Preprocessor from preprocessor_64.pkl\n",
+            "INFO:utils.pipeline:Loading Preprocessor from preprocessor_128.pkl\n",
+            "INFO:src.inference_pipeline:Preprocessors loaded successfully.\n",
+            "INFO:src.inference_pipeline:Loading ws64 models...\n",
+            "I0000 00:00:1753142598.792061  608809 gpu_device.cc:2019] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 5660 MB memory:  -> device: 0, name: NVIDIA GeForce RTX 3050, pci bus id: 0000:01:00.0, compute capability: 8.6\n",
+            "INFO:src.inference_pipeline:Loading ws128 models...\n",
+            "INFO:src.inference_pipeline:Loaded 5 ws64 models and 5 ws128 models.\n"
+          ]
+        }
+      ],
+      "source": [
+        "import os\n",
+        "from pathlib import Path\n",
+        "import polars as pl\n",
+        "\n",
+        "import kaggle_evaluation.cmi_inference_server\n",
+        "\n",
+        "from src.inference_pipeline import predict_one\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def predict(sequence: pl.DataFrame, demographics: pl.DataFrame) -> str:\n",
+        "    return predict_one(sequence, demographics)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "INFO:src.inference_pipeline:Starting ensemble inference for one sample.\n",
+            "INFO:src.inference_pipeline:Processing with ws64 preprocessor...\n",
+            "INFO:utils.pipeline:Transforming dataframe of shape (79, 343)\n",
+            "/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/feature_engineering.py:171: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+            "  df[flag] = df[cols].isna().all(axis=1)\n",
+            "/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/feature_engineering.py:171: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+            "  df[flag] = df[cols].isna().all(axis=1)\n",
+            "/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/feature_engineering.py:171: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`\n",
+            "  df[flag] = df[cols].isna().all(axis=1)\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "fcb1e82527644496a2a063d38d175129",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "interp:   0%|          | 0/1 [00:00<?, ?seq/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "ec76f94576054c2fab51a21ec36db505",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "concat:   0%|          | 0/1 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "INFO:utils.pipeline:Building windows (size=64, stride=32, min_len=20)\n",
+            "INFO:utils.pipeline:Windows shapes: X_sensor=(1, 64, 18), X_demo=(1, 7), y=(1,)\n",
+            "INFO:utils.pipeline:Window tensor shape (1, 64, 18)\n",
+            "INFO:utils.pipeline:Building tabular features (wavelet=True, tda=True, tof_event=False, temp_grad=False)\n",
+            "INFO:utils.pipeline:Tabular features shape (1, 409)\n",
+            "ERROR:src.inference_pipeline:Error in ws64 processing: X has 409 features, but StandardScaler is expecting 392 features as input.\n",
+            "ERROR:grpc._server:Exception calling application: X has 409 features, but StandardScaler is expecting 392 features as input.\n",
+            "Traceback (most recent call last):\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/grpc/_server.py\", line 610, in _call_behavior\n",
+            "    response_or_iterator = behavior(argument, context)\n",
+            "                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/relay.py\", line 354, in Send\n",
+            "    response_payload = _serialize(response_function(*args, **kwargs))\n",
+            "                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/tmp/ipykernel_608809/132370808.py\", line 2, in predict\n",
+            "    return predict_one(sequence, demographics)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/inference_pipeline.py\", line 109, in predict_one\n",
+            "    data_64 = preprocessor_64.transform(combined_df.copy(), use_cache=False)\n",
+            "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/src/utils/pipeline.py\", line 762, in transform\n",
+            "    tab_normalized = self.tab_scaler.transform(tab_clean)\n",
+            "                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/utils/_set_output.py\", line 157, in wrapped\n",
+            "    data_to_wrap = f(self, X, *args, **kwargs)\n",
+            "                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/preprocessing/_data.py\", line 1006, in transform\n",
+            "    X = self._validate_data(\n",
+            "        ^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/base.py\", line 626, in _validate_data\n",
+            "    self._check_n_features(X, reset=reset)\n",
+            "  File \"/mnt/c/Users/ShunK/works/CMI_comp/.venv/lib/python3.11/site-packages/sklearn/base.py\", line 415, in _check_n_features\n",
+            "    raise ValueError(\n",
+            "ValueError: X has 409 features, but StandardScaler is expecting 392 features as input.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "✅ TDA処理前: NaN値なし\n"
+          ]
+        },
+        {
+          "ename": "GatewayRuntimeError",
+          "evalue": "(<GatewayRuntimeErrorType.SERVER_RAISED_EXCEPTION: 3>, 'X has 409 features, but StandardScaler is expecting 392 features as input.')",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mGatewayRuntimeError\u001b[39m                       Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 17\u001b[39m\n\u001b[32m     10\u001b[39m     inference_server.run_local_gateway(\n\u001b[32m     11\u001b[39m         data_paths=(\n\u001b[32m     12\u001b[39m             \u001b[33m'\u001b[39m\u001b[33m/kaggle/input/cmi-detect-behavior-with-sensor-data/test.csv\u001b[39m\u001b[33m'\u001b[39m,\n\u001b[32m     13\u001b[39m             \u001b[33m'\u001b[39m\u001b[33m/kaggle/input/cmi-detect-behavior-with-sensor-data/test_demographics.csv\u001b[39m\u001b[33m'\u001b[39m,\n\u001b[32m     14\u001b[39m         )\n\u001b[32m     15\u001b[39m     )\n\u001b[32m     16\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m17\u001b[39m     \u001b[43minference_server\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun_local_gateway\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     18\u001b[39m \u001b[43m        \u001b[49m\u001b[43mdata_paths\u001b[49m\u001b[43m=\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     19\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43m../data/split/test.csv\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     20\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43m../data/split/test_demographics.csv\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     21\u001b[39m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     22\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:149\u001b[39m, in \u001b[36mInferenceServer.run_local_gateway\u001b[39m\u001b[34m(self, data_paths, file_share_dir, *args, **kwargs)\u001b[39m\n\u001b[32m    147\u001b[39m     \u001b[38;5;28mself\u001b[39m.gateway.run()\n\u001b[32m    148\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[32m--> \u001b[39m\u001b[32m149\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m err \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    150\u001b[39m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[32m    151\u001b[39m     \u001b[38;5;28mself\u001b[39m.server.stop(\u001b[32m0\u001b[39m)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:147\u001b[39m, in \u001b[36mInferenceServer.run_local_gateway\u001b[39m\u001b[34m(self, data_paths, file_share_dir, *args, **kwargs)\u001b[39m\n\u001b[32m    145\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m    146\u001b[39m     \u001b[38;5;28mself\u001b[39m.gateway = \u001b[38;5;28mself\u001b[39m._get_gateway_for_test(data_paths, file_share_dir, *args, **kwargs)\n\u001b[32m--> \u001b[39m\u001b[32m147\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mgateway\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    148\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[32m    149\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m err \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:105\u001b[39m, in \u001b[36mGateway.run\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    102\u001b[39m     \u001b[38;5;28mself\u001b[39m.write_result(error)\n\u001b[32m    103\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m error:\n\u001b[32m    104\u001b[39m     \u001b[38;5;66;03m# For local testing\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m105\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m error\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:84\u001b[39m, in \u001b[36mGateway.run\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m     82\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m     83\u001b[39m     \u001b[38;5;28mself\u001b[39m.unpack_data_paths()\n\u001b[32m---> \u001b[39m\u001b[32m84\u001b[39m     predictions, row_ids = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mget_all_predictions\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     85\u001b[39m     \u001b[38;5;28mself\u001b[39m.write_submission(predictions, row_ids)\n\u001b[32m     86\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m kaggle_evaluation.core.base_gateway.GatewayRuntimeError \u001b[38;5;28;01mas\u001b[39;00m gre:\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:56\u001b[39m, in \u001b[36mGateway.get_all_predictions\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m     54\u001b[39m all_row_ids = []\n\u001b[32m     55\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m data_batch, row_ids \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.generate_data_batches():\n\u001b[32m---> \u001b[39m\u001b[32m56\u001b[39m     predictions = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mpredict\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43mdata_batch\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     57\u001b[39m     \u001b[38;5;28mself\u001b[39m.validate_prediction_batch(predictions, row_ids)\n\u001b[32m     58\u001b[39m     all_predictions.append(predictions)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/templates.py:72\u001b[39m, in \u001b[36mGateway.predict\u001b[39m\u001b[34m(self, *args, **kwargs)\u001b[39m\n\u001b[32m     70\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m.client.send(\u001b[33m'\u001b[39m\u001b[33mpredict\u001b[39m\u001b[33m'\u001b[39m, *args, **kwargs)\n\u001b[32m     71\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m---> \u001b[39m\u001b[32m72\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mhandle_server_error\u001b[49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mpredict\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m/mnt/c/Users/ShunK/works/CMI_comp/submissions/v40/kaggle_evaluation/core/base_gateway.py:257\u001b[39m, in \u001b[36mBaseGateway.handle_server_error\u001b[39m\u001b[34m(self, exception, endpoint)\u001b[39m\n\u001b[32m    255\u001b[39m     message_match = re.search(\u001b[33m'\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mException calling application: (.*)\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m'\u001b[39m, exception_str, re.IGNORECASE)\n\u001b[32m    256\u001b[39m     message = message_match.group(\u001b[32m1\u001b[39m) \u001b[38;5;28;01mif\u001b[39;00m message_match \u001b[38;5;28;01melse\u001b[39;00m exception_str\n\u001b[32m--> \u001b[39m\u001b[32m257\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m GatewayRuntimeError(GatewayRuntimeErrorType.SERVER_RAISED_EXCEPTION, message) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    258\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(exception, grpc._channel._InactiveRpcError):\n\u001b[32m    259\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m GatewayRuntimeError(GatewayRuntimeErrorType.SERVER_CONNECTION_FAILED, exception_str) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n",
+            "\u001b[31mGatewayRuntimeError\u001b[39m: (<GatewayRuntimeErrorType.SERVER_RAISED_EXCEPTION: 3>, 'X has 409 features, but StandardScaler is expecting 392 features as input.')"
+          ]
+        }
+      ],
+      "source": [
+        "inference_server = kaggle_evaluation.cmi_inference_server.CMIInferenceServer(predict)\n",
+        "\n",
+        "def is_kaggle():\n",
+        "    return \"KAGGLE_URL_BASE\" in os.environ or Path(\"/kaggle\").exists()\n",
+        "\n",
+        "if os.getenv('KAGGLE_IS_COMPETITION_RERUN'):\n",
+        "    inference_server.serve()\n",
+        "else:\n",
+        "    if is_kaggle():\n",
+        "        inference_server.run_local_gateway(\n",
+        "            data_paths=(\n",
+        "                '/kaggle/input/cmi-detect-behavior-with-sensor-data/test.csv',\n",
+        "                '/kaggle/input/cmi-detect-behavior-with-sensor-data/test_demographics.csv',\n",
+        "            )\n",
+        "        )\n",
+        "    else:\n",
+        "        inference_server.run_local_gateway(\n",
+        "            data_paths=(\n",
+        "                '../data/split/test.csv',\n",
+        "                '../data/split/test_demographics.csv',\n",
+        "            )\n",
+        "        )\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Shape: (102, 2)\n",
+            "Columns: ['sequence_id', 'gesture']\n",
+            "First 10 rows:\n",
+            "  sequence_id                    gesture\n",
+            "0  SEQ_060707         Cheek - pinch skin\n",
+            "1  SEQ_037923              Text on phone\n",
+            "2  SEQ_028006   Forehead - pull hairline\n",
+            "3  SEQ_020034      Above ear - pull hair\n",
+            "4  SEQ_016979        Eyebrow - pull hair\n",
+            "5  SEQ_037140      Above ear - pull hair\n",
+            "6  SEQ_062937             Neck - scratch\n",
+            "7  SEQ_025391          Neck - pinch skin\n",
+            "8  SEQ_064204  Pull air toward your face\n",
+            "9  SEQ_063950         Cheek - pinch skin\n",
+            "Value counts:\n",
+            "gesture\n",
+            "Neck - scratch                                20\n",
+            "Cheek - pinch skin                            13\n",
+            "Neck - pinch skin                             13\n",
+            "Text on phone                                 11\n",
+            "Wave hello                                     7\n",
+            "Eyebrow - pull hair                            6\n",
+            "Eyelash - pull hair                            6\n",
+            "Above ear - pull hair                          5\n",
+            "Forehead - scratch                             5\n",
+            "Forehead - pull hairline                       3\n",
+            "Pull air toward your face                      3\n",
+            "Glasses on/off                                 3\n",
+            "Pinch knee/leg skin                            3\n",
+            "Write name in air                              2\n",
+            "Feel around in tray and pull out an object     1\n",
+            "Write name on leg                              1\n",
+            "Name: count, dtype: int64\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Check submission file\n",
+        "import pandas as pd\n",
+        "df = pd.read_parquet('submission.parquet')\n",
+        "print('Shape:', df.shape)\n",
+        "print('Columns:', df.columns.tolist())\n",
+        "print('First 10 rows:')\n",
+        "print(df.head(10))\n",
+        "print('Value counts:')\n",
+        "print(df['gesture'].value_counts())\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "CMI評価指標計算開始...\n",
+            "y_true shape: (102,), y_pred shape: (102,)\n",
+            "ラベル変換完了: 102 samples\n",
+            "データ中のジェスチャー: 18種類\n",
+            "Binary分類 - Target: 64, Non-Target: 38\n",
+            "Binary F1: 0.6963\n",
+            "Macro F1: 0.1124\n",
+            "CMI Score: 0.4044\n",
+            "Test Accuracy: 0.0588\n",
+            "CMI Score: 0.4044, Binary F1: 0.6963, Macro F1: 0.1124, Accuracy: 0.0588\n"
+          ]
+        }
+      ],
+      "source": [
+        "import pandas as pd\n",
+        "from src.utils.cmi_evaluation import calculate_cmi_score\n",
+        "\n",
+        "# 例: 推論結果\n",
+        "df_pred = pd.read_parquet('submission.parquet')  # またはcsv等\n",
+        "# 例: 正解ラベル\n",
+        "df_true = pd.read_csv('../data/split/test_labels.csv')\n",
+        "\n",
+        "# ラベル名が一致している前提\n",
+        "y_pred = df_pred['gesture'].values\n",
+        "y_true = df_true['gesture'].values\n",
+        "\n",
+        "# 必要ならLabelEncoderでエンコード\n",
+        "from sklearn.preprocessing import LabelEncoder\n",
+        "le = LabelEncoder()\n",
+        "le.fit(list(y_true) + list(y_pred))\n",
+        "y_true_enc = le.transform(y_true)\n",
+        "y_pred_enc = le.transform(y_pred)\n",
+        "\n",
+        "# CMIスコア計算\n",
+        "cmi_score, binary_f1, macro_f1, test_acc = calculate_cmi_score(y_pred_enc, y_true_enc, label_encoder=le, verbose=True)\n",
+        "print(f'CMI Score: {cmi_score:.4f}, Binary F1: {binary_f1:.4f}, Macro F1: {macro_f1:.4f}, Accuracy: {test_acc:.4f}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Target / Non‑target 比率 (%)\n",
+            "sequence_type  Non-Target  Target\n",
+            "fold                             \n",
+            "0                    39.7    60.3\n",
+            "1                    40.4    59.6\n",
+            "2                    40.3    59.7\n",
+            "3                    40.4    59.6\n",
+            "4                    40.0    60.0\n"
+          ]
+        }
+      ],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.5"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/submissions/v40_64and128/config_ws128.yaml
+++ b/submissions/v40_64and128/config_ws128.yaml
@@ -1,0 +1,1 @@
+../../config/config_v40_ws128.yaml

--- a/submissions/v40_64and128/config_ws64.yaml
+++ b/submissions/v40_64and128/config_ws64.yaml
@@ -1,0 +1,1 @@
+../../config/config_v40_ws64.yaml

--- a/submissions/v40_64and128/models_128
+++ b/submissions/v40_64and128/models_128
@@ -1,0 +1,1 @@
+../../output/experiments/preprocess_v2_ws128/models

--- a/submissions/v40_64and128/models_64
+++ b/submissions/v40_64and128/models_64
@@ -1,0 +1,1 @@
+../../output/experiments/preprocess_v2_ws64/models

--- a/submissions/v40_64and128/prepare.sh
+++ b/submissions/v40_64and128/prepare.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Create necessary directories
+mkdir -p src/utils
+mkdir -p src/trainers
+
+# Copy essential source files
+cp -p ../../src/utils/pipeline.py ./src/utils/
+cp -p ../../src/utils/kaggle.py ./src/utils/
+cp -p ../../src/utils/cmi_evaluation.py ./src/utils/
+cp -p ../../src/utils/config_utils.py ./src/utils/
+cp -p ../../src/trainers/multimodal_trainer_v40.py ./src/trainers/
+cp -p ../../src/utils/preprocessing.py ./src/utils/
+cp -p ../../src/utils/tof.py ./src/utils/
+cp -p ../../src/utils/imu.py ./src/utils/
+cp -p ../../src/utils/feature_engineering.py ./src/utils/
+cp -p ../../src/utils/io_utils.py ./src/utils/
+
+
+# Link models and preprocessors for both window sizes
+ln -s ../../output/experiments/preprocess_v2_ws64/models models_64
+ln -s ../../output/experiments/preprocess_v2_ws64/preprocessed/preprocessor.pkl preprocessor_64.pkl
+
+ln -s ../../output/experiments/preprocess_v2_ws128/models models_128
+ln -s ../../output/experiments/preprocess_v2_ws128/preprocessed/preprocessor.pkl preprocessor_128.pkl
+
+# Link config files for both window sizes
+ln -s ../../config/config_v40_ws64.yaml config_ws64.yaml
+ln -s ../../config/config_v40_ws128.yaml config_ws128.yaml
+
+# Create a dummy kaggle_evaluation link if it doesn't exist, for local testing
+if [ ! -d "kaggle_evaluation" ]; then
+    ln -s ../../data/kaggle_evaluation kaggle_evaluation
+fi
+

--- a/submissions/v40_64and128/src/inference_pipeline.py
+++ b/submissions/v40_64and128/src/inference_pipeline.py
@@ -1,0 +1,158 @@
+import sys
+from pathlib import Path
+import numpy as np
+import polars as pl
+import pandas as pd
+import tensorflow as tf
+import logging
+
+# Add the submission-specific src directory to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from utils.pipeline import Preprocessor
+from utils.config_utils import load_config
+from utils.kaggle import is_kaggle
+
+# Logging settings
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# --- Model and Preprocessor Loading ---
+def load_models_and_preprocessors():
+    """Load all models and preprocessors for ensemble."""
+    
+    if is_kaggle():
+        # Kaggle environment paths
+        base_path_64 = Path("/kaggle/input/cmi-v40-ws64")
+        base_path_128 = Path("/kaggle/input/cmi-v40-ws128")
+        models_dir_64 = base_path_64 / "models_64"
+        preprocessor_path_64 = base_path_64 / "preprocessor_64.pkl"
+        config_path_64 = base_path_64 / "config_ws64.yaml"
+        models_dir_128 = base_path_128 / "models_128"
+        preprocessor_path_128 = base_path_128 / "preprocessor_128.pkl"
+        config_path_128 = base_path_128 / "config_ws128.yaml"
+    else:
+        # Local environment paths
+        models_dir_64 = Path("models_64")
+        preprocessor_path_64 = Path("preprocessor_64.pkl")
+        config_path_64 = Path("config_ws64.yaml")
+        models_dir_128 = Path("models_128")
+        preprocessor_path_128 = Path("preprocessor_128.pkl")
+        config_path_128 = Path("config_ws128.yaml")
+
+    # Load configs
+    logger.info("Loading configurations...")
+    config_64 = load_config(config_path_64) if config_path_64.exists() else None
+    config_128 = load_config(config_path_128) if config_path_128.exists() else None
+    
+    # Load preprocessors
+    logger.info("Loading preprocessors...")
+    preprocessor_64 = Preprocessor.load(preprocessor_path_64)
+    preprocessor_128 = Preprocessor.load(preprocessor_path_128)
+    
+    # Update preprocessor configs if available
+    if config_64:
+        logger.info("Applying ws64 config to preprocessor_64")
+        preprocessor_64.config.update(config_64)
+    if config_128:
+        logger.info("Applying ws128 config to preprocessor_128")
+        preprocessor_128.config.update(config_128)
+    
+    logger.info("Preprocessors loaded successfully.")
+    
+    # Load models
+    models_64 = []
+    models_128 = []
+
+    logger.info("Loading ws64 models...")
+    for fold in range(1, 6):
+        model_path = models_dir_64 / f"multimodal_model_v40_fold{fold}.keras"
+        if model_path.exists():
+            models_64.append(tf.keras.models.load_model(model_path))
+        else:
+            raise FileNotFoundError(f"Model not found: {model_path}")
+
+    logger.info("Loading ws128 models...")
+    for fold in range(1, 6):
+        model_path = models_dir_128 / f"multimodal_model_v40_fold{fold}.keras"
+        if model_path.exists():
+            models_128.append(tf.keras.models.load_model(model_path))
+        else:
+            raise FileNotFoundError(f"Model not found: {model_path}")
+
+    if not models_64 or not models_128:
+        raise ValueError("Models for ws64 or ws128 could not be loaded.")
+
+    logger.info(f"Loaded {len(models_64)} ws64 models and {len(models_128)} ws128 models.")
+    
+    return preprocessor_64, models_64, preprocessor_128, models_128
+
+preprocessor_64, models_64, preprocessor_128, models_128 = load_models_and_preprocessors()
+
+# --- Inference Function ---
+def predict_one(sequence: pl.DataFrame, demographics: pl.DataFrame) -> str:
+    """
+    Perform ensemble inference on one sample using ws64 and ws128 models.
+    """
+    logger.info("Starting ensemble inference for one sample.")
+    
+    # Convert polars to pandas
+    seq_df = sequence.to_pandas()
+    demo_df = demographics.to_pandas()
+    combined_df = seq_df.merge(demo_df, on="subject", how="left")
+    
+    all_final_preds = []
+
+    # --- Inference with ws64 ---
+    logger.info("Processing with ws64 preprocessor...")
+    try:
+        data_64 = preprocessor_64.transform(combined_df.copy(), use_cache=False)
+        inputs_64 = [
+            data_64["windows"],
+            data_64["demographics"],
+            data_64["tabular"],
+            data_64["tof_windows"],
+        ]
+        
+        preds_64 = [model.predict(inputs_64, verbose=0) for model in models_64]
+        avg_pred_64 = np.mean(preds_64, axis=0)
+        all_final_preds.append(avg_pred_64)
+        logger.info(f"ws64 prediction completed. Shape: {avg_pred_64.shape}")
+    except Exception as e:
+        logger.error(f"Error in ws64 processing: {e}")
+        raise
+
+    # --- Inference with ws128 ---
+    logger.info("Processing with ws128 preprocessor...")
+    try:
+        data_128 = preprocessor_128.transform(combined_df.copy(), use_cache=False)
+        inputs_128 = [
+            data_128["windows"],
+            data_128["demographics"],
+            data_128["tabular"],
+            data_128["tof_windows"],
+        ]
+
+        preds_128 = [model.predict(inputs_128, verbose=0) for model in models_128]
+        avg_pred_128 = np.mean(preds_128, axis=0)
+        all_final_preds.append(avg_pred_128)
+        logger.info(f"ws128 prediction completed. Shape: {avg_pred_128.shape}")
+    except Exception as e:
+        logger.error(f"Error in ws128 processing: {e}")
+        raise
+
+    # --- Ensemble predictions ---
+    final_avg_pred = np.mean(all_final_preds, axis=0)
+    logger.info(f"Ensemble prediction completed. Shape: {final_avg_pred.shape}")
+    
+    # Convert prediction to label
+    label_index = np.argmax(final_avg_pred, axis=1)[0]
+    
+    # Use the label encoder from one of the preprocessors (they should be identical)
+    if hasattr(preprocessor_64, 'label_encoder') and preprocessor_64.label_encoder is not None:
+        predicted_label = preprocessor_64.label_encoder.inverse_transform([label_index])[0]
+    else:
+        predicted_label = f"gesture_{label_index}"
+        
+    logger.info(f"Final predicted label: {predicted_label}")
+    return predicted_label 

--- a/submissions/v40_64and128/src/trainers/multimodal_trainer_v40.py
+++ b/submissions/v40_64and128/src/trainers/multimodal_trainer_v40.py
@@ -1,0 +1,614 @@
+"""多モダリティ学習用トレーナー
+
+IMUウィンドウ、人口統計、表形式特徴量、ToFボクセルの4種類の前処理済みデータに加え、
+ToFイベント特徴量や温度勾配特徴量などの拡張タブular特徴量を利用して学習を行う。
+少数クラスを考慮するため、``_train_fold`` では
+``sklearn.utils.class_weight.compute_class_weight`` を使ってクラス重みを計算し、
+``model.fit()`` に ``class_weight`` として渡す。
+"""
+
+from __future__ import annotations
+
+import os
+import json
+import pickle
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.model_selection import (
+    train_test_split,
+    StratifiedGroupKFold,
+)
+from sklearn.metrics import classification_report, f1_score
+from sklearn.utils.class_weight import compute_class_weight
+
+from src.utils.cmi_evaluation import calculate_cmi_score
+from src.utils.pipeline import Preprocessor
+import tensorflow as tf
+from tensorflow import keras
+
+
+class MultimodalTrainerV40:
+    """多モダリティモデル学習管理クラス（v40）"""
+
+    def __init__(self, experiment_name: str = "multimodal") -> None:
+        self.experiment_name = experiment_name
+        self.base_dir = Path("output/experiments") / experiment_name
+        self.data_dir = self.base_dir / "preprocessed"
+        self.model_dir = self.base_dir / "models"
+        self.result_dir = self.base_dir / "results"
+
+        self.model_dir.mkdir(parents=True, exist_ok=True)
+        self.result_dir.mkdir(parents=True, exist_ok=True)
+
+        print(f"Experiment name: {self.experiment_name}")
+        print(f"Data directory: {self.data_dir}")
+
+    def _resnet_block_3d(self, x: tf.Tensor, filters: int, kernel_size: int = 3, stride: int = 1) -> tf.Tensor:
+        """3D ResNet ブロック"""
+        shortcut = x
+
+        # メインパス
+        y = keras.layers.Conv3D(filters, kernel_size, strides=stride, padding="same")(x)
+        y = keras.layers.BatchNormalization()(y)
+        y = keras.layers.ReLU()(y)
+
+        y = keras.layers.Conv3D(filters, kernel_size, padding="same")(y)
+        y = keras.layers.BatchNormalization()(y)
+
+        # ショートカットパス
+        if stride != 1 or x.shape[-1] != filters:
+            shortcut = keras.layers.Conv3D(filters, 1, strides=stride, padding="same")(shortcut)
+            shortcut = keras.layers.BatchNormalization()(shortcut)
+
+        # Add & ReLU
+        y = keras.layers.Add()([y, shortcut])
+        y = keras.layers.ReLU()(y)
+        y = keras.layers.SpatialDropout3D(0.2)(y)
+        return y
+
+    def load_all_data(self) -> Dict[str, np.ndarray]:
+        """各モダリティの前処理済みデータをすべて読み込む
+
+        追加で ``train_info.pkl`` を読み込み、``subject`` または ``sequence_id``
+        の配列を ``groups`` キーで返す。
+        """
+        print("前処理済みデータを読み込み中...")
+
+        def _load(name: str) -> np.ndarray:
+            npy = self.data_dir / f"{name}.npy"
+            pkl = self.data_dir / f"{name}.pkl"
+            if npy.exists():
+                return np.load(npy)
+            if pkl.exists():
+                with open(pkl, "rb") as f:
+                    return pickle.load(f)
+            raise FileNotFoundError(f"{name} ファイルが見つかりません")
+
+        X_sensor = _load("train_windows")
+        X_demo = _load("train_demographics")
+        X_tab = _load("train_tabular")
+        X_tab = X_tab.astype(np.float32)
+        X_tof = _load("train_tof_windows")
+        y = _load("train_labels")
+        info = _load("train_info")
+
+        if isinstance(info, list) and len(info) > 0 and isinstance(info[0], dict):
+            groups = np.array([
+                d.get("subject") for d in info
+            ])
+        else:
+            groups = np.asarray(info)
+
+        print(f"センサー: {X_sensor.shape}")
+        print(f"人口統計: {X_demo.shape}")
+        print(f"表形式: {X_tab.shape}")
+        print(f"ToF: {X_tof.shape}")
+        print(f"ラベル: {y.shape}")
+        print(f"グループ数: {len(groups)}")
+
+        return {
+            "sensor": X_sensor,
+            "demographics": X_demo,
+            "tabular": X_tab,
+            "tof": X_tof,
+            "labels": y,
+            "groups": groups,
+        }
+
+    def build_multimodal_model(
+        self,
+        sensor_shape: tuple,
+        demo_shape: int,
+        tab_shape: int,
+        tof_shape: tuple,
+        num_classes: int,
+        *,
+        use_attention: bool = False,
+    ) -> keras.Model:
+        """タワー型統合ネットワークを構築"""
+        # 1. IMU Tower (Bidirectional LSTM)
+        sensor_input = keras.Input(shape=sensor_shape, name="sensor")
+        x1 = keras.layers.Masking()(sensor_input)
+        x1 = keras.layers.Bidirectional(keras.layers.LSTM(32))(x1)
+
+        # 2. Demographics Tower
+        demo_input = keras.Input(shape=(demo_shape,), name="demo")
+        x2 = keras.layers.Dense(32, activation="relu")(demo_input)
+
+        # 3. Tabular Tower (Residual Connection)
+        tab_input = keras.Input(shape=(tab_shape,), name="tabular")
+        x3_base = keras.layers.Dense(64, activation="relu")(tab_input)
+        x3_res = keras.layers.Dense(64, activation="relu")(x3_base)
+        x3 = keras.layers.Add()([x3_base, x3_res])
+
+        # 4. ToF Tower (3D ResNet)
+        tof_input = keras.Input(shape=tof_shape, name="tof")
+        x4 = self._resnet_block_3d(tof_input, filters=16, stride=2)
+        x4 = self._resnet_block_3d(x4, filters=32, stride=2)
+        if use_attention:
+            x4 = keras.layers.SpatialDropout3D(0.2)(x4)
+        x4 = keras.layers.GlobalAveragePooling3D()(x4)
+
+        if use_attention:
+            # IMU と ToF 特徴量間でアテンションを計算
+            q = keras.layers.Reshape((1, 64))(keras.layers.Dense(64)(x1))
+            v = keras.layers.Reshape((1, 64))(keras.layers.Dense(64)(x4))
+            attn = keras.layers.MultiHeadAttention(num_heads=4, key_dim=64)(q, v)
+            attn = keras.layers.Flatten()(attn)
+            merged = keras.layers.concatenate([attn, x2, x3])
+        else:
+            merged = keras.layers.concatenate([x1, x2, x3, x4])
+        merged = keras.layers.Dense(64, activation="relu")(merged)
+        merged = keras.layers.Dropout(0.3)(merged)
+        output = keras.layers.Dense(num_classes, activation="softmax")(merged)
+
+        model = keras.Model(
+            inputs=[sensor_input, demo_input, tab_input, tof_input], outputs=output
+        )
+
+        lr_schedule = keras.optimizers.schedules.ExponentialDecay(
+            initial_learning_rate=1e-3,
+            decay_steps=1000,
+            decay_rate=0.96,
+            staircase=True,
+        )
+        optimizer = keras.optimizers.Adam(learning_rate=lr_schedule)
+
+        model.compile(
+            optimizer=optimizer,
+            loss="sparse_categorical_crossentropy",
+            metrics=["accuracy"],
+        )
+        print(model.summary())
+        return model
+
+    def _train_fold(
+        self,
+        X_s: np.ndarray,
+        X_d: np.ndarray,
+        X_t: np.ndarray,
+        X_f: np.ndarray,
+        y: np.ndarray,
+        train_idx: np.ndarray,
+        val_idx: np.ndarray,
+        *,
+        epochs: int = 50,
+        batch_size: int = 32,
+        use_attention: bool = False,
+    ) -> tuple[keras.Model, keras.callbacks.History, float, float]:
+        """単一foldでモデルを学習しF1スコアを返す"""
+        model = self.build_multimodal_model(
+            sensor_shape=X_s.shape[1:],
+            demo_shape=X_d.shape[1],
+            tab_shape=X_t.shape[1],
+            tof_shape=X_f.shape[1:],
+            num_classes=len(np.unique(y)),
+            use_attention=use_attention,
+        )
+        classes = np.unique(y)
+        weights = compute_class_weight(class_weight="balanced", classes=classes, y=y[train_idx])
+        class_weight = {cls: w for cls, w in zip(classes, weights)}
+        history = model.fit(
+            [X_s[train_idx], X_d[train_idx], X_t[train_idx], X_f[train_idx]],
+            y[train_idx],
+            validation_data=(
+                [X_s[val_idx], X_d[val_idx], X_t[val_idx], X_f[val_idx]],
+                y[val_idx],
+            ),
+            epochs=epochs,
+            batch_size=batch_size,
+            class_weight=class_weight,
+            callbacks=[keras.callbacks.EarlyStopping(patience=10, restore_best_weights=True)],
+            verbose=1,
+        )
+        preds = model.predict([X_s[val_idx], X_d[val_idx], X_t[val_idx], X_f[val_idx]])
+        pred_labels = preds.argmax(axis=1)
+        f1 = f1_score(y[val_idx], pred_labels, average="macro")
+        
+        # CMI-score計算
+        cmi_score, _, _, _ = calculate_cmi_score(pred_labels, y[val_idx])
+        
+        return model, history, float(f1), float(cmi_score)
+
+    def train(
+        self,
+        data: Dict[str, np.ndarray],
+        epochs: int = 50,
+        batch_size: int = 32,
+        *,
+        use_attention: bool = False,
+    ) -> keras.callbacks.History:
+        print("=== データ型確認 ===")
+        print(f"X_sensor dtype: {data['sensor'].dtype}")
+        print(f"X_demo dtype: {data['demographics'].dtype}")
+        print(f"X_tabular dtype: {data['tabular'].dtype}")
+        print(f"X_tof dtype: {data['tof'].dtype}")
+        print(f"y dtype: {data['labels'].dtype}")
+        print(f"y unique values: {np.unique(data['labels'])}")        
+
+        X_s = data["sensor"]
+        X_d = data["demographics"]
+        X_t = data["tabular"]
+        X_f = data["tof"]
+        y = data["labels"]
+
+        Xs_train, Xs_val, yd_train, yd_val = train_test_split(
+            np.arange(len(y)), y, test_size=0.2, stratify=y, random_state=42
+        )
+        model, history, _, _ = self._train_fold(
+            X_s,
+            X_d,
+            X_t,
+            X_f,
+            y,
+            Xs_train,
+            Xs_val,
+            epochs=epochs,
+            batch_size=batch_size,
+            use_attention=use_attention,
+        )
+        self.model = model
+        self.history = history
+        return history
+
+    def train_cross_validation(
+        self,
+        data: Dict[str, np.ndarray],
+        epochs: int = 50,
+        batch_size: int = 32,
+        n_splits: int = 5,
+        groups: np.ndarray | None = None,
+        *,
+        use_attention: bool = False,
+    ) -> Dict[str, Any]:
+        """StratifiedGroupKFold を用いたクロスバリデーション学習"""
+        print("=== データ型確認 ===")
+        print(f"X_sensor dtype: {data['sensor'].dtype}")
+        print(f"X_demo dtype: {data['demographics'].dtype}")
+        print(f"X_tabular dtype: {data['tabular'].dtype}")
+        print(f"X_tof dtype: {data['tof'].dtype}")
+        print(f"y dtype: {data['labels'].dtype}")
+        print(f"y unique values: {np.unique(data['labels'])}")
+
+        X_s = data["sensor"]
+        X_d = data["demographics"]
+        X_t = data["tabular"]
+        X_f = data["tof"]
+        y = data["labels"]
+
+        if groups is None:
+            groups = data.get("groups")
+
+        skf = StratifiedGroupKFold(n_splits=n_splits, shuffle=True, random_state=42)
+        fold_scores: list[float] = []
+        fold_cmi_scores: list[float] = []
+
+        fold_histories = []
+        for fold, (tr_idx, val_idx) in enumerate(skf.split(np.arange(len(y)), y, groups), 1):
+            print(f"Fold {fold}/{n_splits}")
+            model, history, f1, cmi_score = self._train_fold(
+                X_s,
+                X_d,
+                X_t,
+                X_f,
+                y,
+                tr_idx,
+                val_idx,
+                epochs=epochs,
+                batch_size=batch_size,
+                use_attention=use_attention,
+            )
+            fold_scores.append(f1)
+            fold_cmi_scores.append(cmi_score)
+            fold_histories.append(history)
+            
+            # モデル保存
+            model_path = self.model_dir / f"multimodal_model_v40_fold{fold}.keras"
+            model.save(model_path)
+            print(f"モデル保存: {model_path}")
+            
+            # 各foldの学習履歴保存
+            history_path = self.result_dir / f"training_history_fold{fold}.json"
+            self._save_history(history, history_path)
+
+        mean_score = float(np.mean(fold_scores))
+        std_score = float(np.std(fold_scores))
+        mean_cmi = float(np.mean(fold_cmi_scores))
+        std_cmi = float(np.std(fold_cmi_scores))
+        cv_results = {
+            "fold_scores": [float(s) for s in fold_scores],
+            "fold_cmi_scores": [float(s) for s in fold_cmi_scores],
+            "mean_f1": mean_score,
+            "std_f1": std_score,
+            "mean_cmi": mean_cmi,
+            "std_cmi": std_cmi,
+        }
+
+        results_dir = Path("results")
+        results_dir.mkdir(exist_ok=True)
+        with open(results_dir / "cv_results.json", "w", encoding="utf-8") as f:
+            json.dump(cv_results, f, ensure_ascii=False, indent=2)
+        print(f"Cross-validation results saved: {results_dir / 'cv_results.json'}")
+
+        self.cv_results = cv_results
+        
+        # 学習曲線とクロスバリデーション結果をプロット
+        self.plot_training_curves(fold_histories)
+        self.plot_cross_validation_results(cv_results)
+        
+        # 最後のfoldのモデルをself.modelにセット
+        self.model = model
+        
+        return cv_results
+
+    def evaluate(
+        self,
+        data: Dict[str, np.ndarray],
+        *,
+        preprocessor_path: str | Path | None = None,
+    ) -> Dict[str, Any]:
+        X_s = data["sensor"]
+        X_d = data["demographics"]
+        X_t = data["tabular"]
+        X_f = data["tof"]
+        y = data["labels"]
+
+        preds = self.model.predict([X_s, X_d, X_t, X_f])
+        pred_labels = preds.argmax(axis=1)
+
+        label_encoder = None
+        if preprocessor_path is None:
+            preprocessor_path = self.data_dir / "preprocessor.pkl"
+        try:
+            pp_path = Path(preprocessor_path)
+            if pp_path.exists():
+                pp = Preprocessor.load(pp_path)
+                label_encoder = getattr(pp, "label_encoder", None)
+        except Exception as e:
+            print(f"label_encoder 読み込み失敗: {e}")
+
+        cmi_score, binary_f1, macro_f1, test_accuracy = calculate_cmi_score(
+            pred_labels,
+            y,
+            label_encoder=label_encoder,
+        )
+
+        report = classification_report(y, pred_labels, output_dict=True)
+
+        results = {
+            "cmi_score": float(cmi_score),
+            "binary_f1": float(binary_f1),
+            "macro_f1": float(macro_f1),
+            "test_accuracy": float(test_accuracy),
+            "report": report,
+        }
+
+        print(
+            f"CMI Score: {cmi_score:.4f} | Binary F1: {binary_f1:.4f} | "
+            f"Macro F1: {macro_f1:.4f} | Acc: {test_accuracy:.4f}"
+        )
+
+        return results
+
+    def save_model(self, path: str | Path | None = None) -> None:
+        save_path: Path
+        if path is None:
+            save_path = self.model_dir / "multimodal_model.keras"
+        else:
+            save_path = Path(path)
+        self.model.save(save_path)
+        print(f"モデル保存: {save_path}")
+
+    def _save_history(self, history, path: Path) -> None:
+        """学習履歴を保存する内部メソッド"""
+        if hasattr(history, "history"):
+            history_dict = history.history
+        else:
+            history_dict = history
+
+        with open(path, "w") as f:
+            json.dump(history_dict, f, indent=2)
+        print(f"学習履歴保存: {path}")
+
+    def save_training_history(self, path: str | Path | None = None) -> Path:
+        save_path: Path
+        if path is None:
+            save_path = self.result_dir / "training_history.json"
+        else:
+            save_path = Path(path)
+
+        if self.history is None:
+            raise ValueError("history is not set")
+
+        self._save_history(self.history, save_path)
+        return save_path
+
+    def save_evaluation_results(
+        self, results: dict, path: str | Path | None = None
+    ) -> None:
+        save_path: Path
+        if path is None:
+            save_path = self.result_dir / "evaluation_results.json"
+        else:
+            save_path = Path(path)
+
+        def _convert(obj: Any):
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+            if isinstance(obj, (np.floating, float)):
+                return float(obj)
+            if isinstance(obj, (np.integer, int)):
+                return int(obj)
+            return obj
+
+        serializable = {k: _convert(v) for k, v in results.items()}
+        with open(save_path, "w", encoding="utf-8") as f:
+            json.dump(serializable, f, ensure_ascii=False, indent=2)
+        print(f"評価結果保存: {save_path}")
+
+    def plot_training_curves(self, fold_histories: list | None = None, save_path: str | Path | None = None) -> None:
+        """学習曲線をプロットして保存する"""
+        if fold_histories is None:
+            if hasattr(self, 'history') and self.history is not None:
+                fold_histories = [self.history]
+            else:
+                print("学習履歴が見つかりません")
+                return
+
+        if save_path is None:
+            save_path = self.result_dir / "training_curves.png"
+        else:
+            save_path = Path(save_path)
+
+        # プロット設定
+        fig, axes = plt.subplots(2, 2, figsize=(15, 10))
+        fig.suptitle('Training Curves (Multimodal Model V40)', fontsize=16)
+
+        metrics = ['loss', 'accuracy']
+        for i, metric in enumerate(metrics):
+            # 訓練データ
+            ax = axes[i, 0]
+            for fold, history in enumerate(fold_histories, 1):
+                if hasattr(history, 'history'):
+                    hist = history.history
+                else:
+                    hist = history
+                
+                if metric in hist:
+                    ax.plot(hist[metric], label=f'Fold {fold}', alpha=0.7)
+            
+            ax.set_title(f'Training {metric.capitalize()}')
+            ax.set_xlabel('Epoch')
+            ax.set_ylabel(metric.capitalize())
+            ax.legend()
+            ax.grid(True, alpha=0.3)
+
+            # 検証データ
+            ax = axes[i, 1]
+            for fold, history in enumerate(fold_histories, 1):
+                if hasattr(history, 'history'):
+                    hist = history.history
+                else:
+                    hist = history
+                
+                val_metric = f'val_{metric}'
+                if val_metric in hist:
+                    ax.plot(hist[val_metric], label=f'Fold {fold}', alpha=0.7)
+            
+            ax.set_title(f'Validation {metric.capitalize()}')
+            ax.set_xlabel('Epoch')
+            ax.set_ylabel(metric.capitalize())
+            ax.legend()
+            ax.grid(True, alpha=0.3)
+
+        plt.tight_layout()
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"学習曲線保存: {save_path}")
+        plt.close()
+
+    def plot_cross_validation_results(self, cv_results: dict | None = None, save_path: str | Path | None = None) -> None:
+        """クロスバリデーション結果をプロットする"""
+        if cv_results is None:
+            if hasattr(self, 'cv_results'):
+                cv_results = self.cv_results
+            else:
+                print("クロスバリデーション結果が見つかりません")
+                return
+
+        if save_path is None:
+            save_path = self.result_dir / "cv_results.png"
+        else:
+            save_path = Path(save_path)
+
+        fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(15, 10))
+        fig.suptitle('Cross-Validation Results', fontsize=16)
+
+        # Fold別F1スコア
+        fold_scores = cv_results.get('fold_scores', [])
+        if fold_scores:
+            ax1.bar(range(1, len(fold_scores) + 1), fold_scores, alpha=0.7, color='blue')
+            ax1.axhline(y=cv_results.get('mean_f1', 0), color='red', linestyle='--', 
+                       label=f'Mean: {cv_results.get("mean_f1", 0):.4f}')
+            ax1.set_xlabel('Fold')
+            ax1.set_ylabel('F1 Score')
+            ax1.set_title('F1 Score by Fold')
+            ax1.legend()
+            ax1.grid(True, alpha=0.3)
+
+        # Fold別CMIスコア
+        fold_cmi_scores = cv_results.get('fold_cmi_scores', [])
+        if fold_cmi_scores:
+            ax2.bar(range(1, len(fold_cmi_scores) + 1), fold_cmi_scores, alpha=0.7, color='green')
+            ax2.axhline(y=cv_results.get('mean_cmi', 0), color='red', linestyle='--', 
+                       label=f'Mean: {cv_results.get("mean_cmi", 0):.4f}')
+            ax2.set_xlabel('Fold')
+            ax2.set_ylabel('CMI Score')
+            ax2.set_title('CMI Score by Fold')
+            ax2.legend()
+            ax2.grid(True, alpha=0.3)
+
+        # F1スコア統計情報
+        mean_f1 = cv_results.get('mean_f1', 0)
+        std_f1 = cv_results.get('std_f1', 0)
+        
+        ax3.text(0.1, 0.8, f'Mean F1: {mean_f1:.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.text(0.1, 0.7, f'Std F1: {std_f1:.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.text(0.1, 0.6, f'Min F1: {min(fold_scores):.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.text(0.1, 0.5, f'Max F1: {max(fold_scores):.4f}', fontsize=12, transform=ax3.transAxes)
+        ax3.set_xlim(0, 1)
+        ax3.set_ylim(0, 1)
+        ax3.set_title('F1 Score Statistics')
+        ax3.axis('off')
+
+        # CMIスコア統計情報
+        mean_cmi = cv_results.get('mean_cmi', 0)
+        std_cmi = cv_results.get('std_cmi', 0)
+        
+        ax4.text(0.1, 0.8, f'Mean CMI: {mean_cmi:.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.text(0.1, 0.7, f'Std CMI: {std_cmi:.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.text(0.1, 0.6, f'Min CMI: {min(fold_cmi_scores):.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.text(0.1, 0.5, f'Max CMI: {max(fold_cmi_scores):.4f}', fontsize=12, transform=ax4.transAxes)
+        ax4.set_xlim(0, 1)
+        ax4.set_ylim(0, 1)
+        ax4.set_title('CMI Score Statistics')
+        ax4.axis('off')
+
+        plt.tight_layout()
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"クロスバリデーション結果保存: {save_path}")
+        plt.close()
+
+
+if __name__ == "__main__":
+    trainer = MultimodalTrainerV40()
+    try:
+        data = trainer.load_all_data()
+        trainer.train(data, epochs=5)
+        trainer.save_model()
+        results = trainer.evaluate(data)
+        print(results)
+    except Exception as e:
+        print(f"エラー: {e}")

--- a/submissions/v40_64and128/src/utils/cmi_evaluation.py
+++ b/submissions/v40_64and128/src/utils/cmi_evaluation.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+CMI Competition Evaluation Module
+
+CMIコンペティション用の評価指標を計算するモジュール
+"""
+
+import numpy as np
+from sklearn.metrics import f1_score, accuracy_score
+
+# ターゲットジェスチャー（刺激行動）
+TARGET_GESTURES = [
+    'Above ear - pull hair',
+    'Cheek - pinch skin', 
+    'Eyebrow - pull hair',
+    'Eyelash - pull hair',
+    'Forehead - pull hairline',
+    'Forehead - scratch',
+    'Neck - pinch skin',
+    'Neck - scratch'
+]
+
+# 非ターゲットジェスチャー（その他の行動）
+NON_TARGET_GESTURES = [
+    'Write name on leg',
+    'Wave hello', 
+    'Glasses on/off',
+    'Text on phone',
+    'Write name in air',
+    'Feel around in tray and pull out an object',
+    'Scratch knee/leg skin',
+    'Pull air toward your face',
+    'Drink from bottle/cup',
+    'Pinch knee/leg skin'
+]
+
+def calculate_cmi_score(y_pred, y_true, label_encoder=None, verbose=False):
+    """
+    CMI コンペティション評価指標の計算
+    
+    Parameters:
+    -----------
+    y_pred : array-like
+        予測ラベル（エンコード済み）
+    y_true : array-like
+        真のラベル（エンコード済み）
+    label_encoder : LabelEncoder, optional
+        ラベルエンコーダー（None の場合は数値ラベルを直接使用）
+    verbose : bool, default=False
+        詳細ログの出力フラグ
+    
+    Returns:
+    --------
+    tuple
+        (CMI スコア, Binary F1, Macro F1, Test Accuracy)
+    """
+    try:
+        if verbose:
+            print(f"CMI評価指標計算開始...")
+            print(f"y_true shape: {np.array(y_true).shape}, y_pred shape: {np.array(y_pred).shape}")
+        
+        # numpy配列に変換
+        y_true = np.array(y_true)
+        y_pred = np.array(y_pred)
+        
+        # Test Accuracy計算
+        test_accuracy = accuracy_score(y_true, y_pred)
+        
+        if label_encoder is not None:
+            # ラベルを元の文字列に変換
+            y_true_str = label_encoder.inverse_transform(y_true)
+            y_pred_str = label_encoder.inverse_transform(y_pred)
+            
+            if verbose:
+                print(f"ラベル変換完了: {len(y_true_str)} samples")
+                unique_gestures = np.unique(np.concatenate([y_true_str, y_pred_str]))
+                print(f"データ中のジェスチャー: {len(unique_gestures)}種類")
+            
+            # 1. Binary F1: Target vs Non-Target
+            y_true_binary = np.array([1 if gesture in TARGET_GESTURES else 0 for gesture in y_true_str])
+            y_pred_binary = np.array([1 if gesture in TARGET_GESTURES else 0 for gesture in y_pred_str])
+            
+            if verbose:
+                print(f"Binary分類 - Target: {np.sum(y_true_binary)}, Non-Target: {np.sum(1-y_true_binary)}")
+            
+            # Zero division回避
+            if len(np.unique(y_true_binary)) == 1 or len(np.unique(y_pred_binary)) == 1:
+                if verbose:
+                    print("Binary分類で単一クラスのみ検出 - F1スコアを0に設定")
+                binary_f1 = 0.0
+            else:
+                binary_f1 = f1_score(y_true_binary, y_pred_binary, average='binary', zero_division='warn')
+            
+            # 2. Macro F1: 全ジェスチャーのマクロF1（非ターゲットは単一クラスに統合）
+            y_true_macro = np.array([gesture if gesture in TARGET_GESTURES else 'non_target' for gesture in y_true_str])
+            y_pred_macro = np.array([gesture if gesture in TARGET_GESTURES else 'non_target' for gesture in y_pred_str])
+            
+            macro_f1 = f1_score(y_true_macro, y_pred_macro, average='macro', zero_division='warn')
+            
+        else:
+            # ラベルエンコーダーがない場合は、マルチクラス分類用のF1スコアを計算
+            if verbose:
+                print("Label encoderなし - マルチクラス分類用F1スコアを計算")
+            
+            # マルチクラス分類ではbinaryは使用できないため、microまたはmacroを使用
+            # ここではmacroを使用（各クラスを平等に扱う）
+            binary_f1 = f1_score(y_true, y_pred, average='macro', zero_division='warn')
+            macro_f1 = f1_score(y_true, y_pred, average='macro', zero_division='warn')
+        
+        # 3. 最終スコア = Binary F1 + Macro F1の平均
+        cmi_score = (binary_f1 + macro_f1) / 2.0
+        
+        if verbose:
+            print(f"Binary F1: {binary_f1:.4f}")
+            print(f"Macro F1: {macro_f1:.4f}")
+            print(f"CMI Score: {cmi_score:.4f}")
+            print(f"Test Accuracy: {test_accuracy:.4f}")
+        
+        return cmi_score, binary_f1, macro_f1, test_accuracy
+        
+    except Exception as e:
+        print(f"CMI評価指標計算でエラー: {str(e)}")
+        import traceback
+        traceback.print_exc()
+        return 0.0, 0.0, 0.0, 0.0
+
+
+def get_target_gestures():
+    """ターゲットジェスチャー一覧を取得"""
+    return TARGET_GESTURES.copy()
+
+
+def get_non_target_gestures():
+    """非ターゲットジェスチャー一覧を取得"""
+    return NON_TARGET_GESTURES.copy()
+
+
+def is_target_gesture(gesture_name):
+    """指定されたジェスチャーがターゲットかどうかを判定"""
+    return gesture_name in TARGET_GESTURES
+
+
+def print_gesture_info():
+    """ジェスチャー情報を出力"""
+    print("=== CMI Competition Gesture Information ===")
+    print(f"Target Gestures ({len(TARGET_GESTURES)}):")
+    for i, gesture in enumerate(TARGET_GESTURES, 1):
+        print(f"  {i:2d}. {gesture}")
+    
+    print(f"\nNon-Target Gestures ({len(NON_TARGET_GESTURES)}):")
+    for i, gesture in enumerate(NON_TARGET_GESTURES, 1):
+        print(f"  {i:2d}. {gesture}")
+    
+    print(f"\nTotal: {len(TARGET_GESTURES) + len(NON_TARGET_GESTURES)} gestures")
+
+
+def add_cmi_metrics_to_history(history_dict, y_true, y_pred, label_encoder=None, verbose=False):
+    """
+    学習履歴辞書にCMI評価指標を追加
+    
+    Parameters:
+    -----------
+    history_dict : dict
+        学習履歴辞書
+    y_true : array-like
+        真のラベル
+    y_pred : array-like
+        予測ラベル
+    label_encoder : LabelEncoder, optional
+        ラベルエンコーダー
+    verbose : bool, default=False
+        詳細ログの出力フラグ
+    
+    Returns:
+    --------
+    dict
+        CMI評価指標が追加された学習履歴辞書
+    """
+    try:
+        # CMI評価指標を計算
+        cmi_score, binary_f1, macro_f1, accuracy = calculate_cmi_score(
+            y_pred, y_true, label_encoder, verbose
+        )
+        
+        # 新しい形式の学習履歴に対応
+        if 'training_metrics' in history_dict and 'validation_metrics' in history_dict:
+            # 新しい詳細形式
+            if 'cmi_score' not in history_dict['training_metrics']:
+                history_dict['training_metrics']['cmi_score'] = []
+            if 'binary_f1' not in history_dict['training_metrics']:
+                history_dict['training_metrics']['binary_f1'] = []
+            if 'macro_f1' not in history_dict['training_metrics']:
+                history_dict['training_metrics']['macro_f1'] = []
+            
+            # 検証データのCMI評価指標も追加（同じ値を使用）
+            if 'cmi_score' not in history_dict['validation_metrics']:
+                history_dict['validation_metrics']['cmi_score'] = []
+            if 'binary_f1' not in history_dict['validation_metrics']:
+                history_dict['validation_metrics']['binary_f1'] = []
+            if 'macro_f1' not in history_dict['validation_metrics']:
+                history_dict['validation_metrics']['macro_f1'] = []
+            
+            # 各エポックに同じ値を追加（実際の学習では各エポックで異なる値になる）
+            epochs = len(history_dict['training_metrics']['loss'])
+            for _ in range(epochs):
+                history_dict['training_metrics']['cmi_score'].append(cmi_score)
+                history_dict['training_metrics']['binary_f1'].append(binary_f1)
+                history_dict['training_metrics']['macro_f1'].append(macro_f1)
+                history_dict['validation_metrics']['cmi_score'].append(cmi_score)
+                history_dict['validation_metrics']['binary_f1'].append(binary_f1)
+                history_dict['validation_metrics']['macro_f1'].append(macro_f1)
+        
+        else:
+            # 古い形式
+            if 'cmi_score' not in history_dict:
+                history_dict['cmi_score'] = []
+            if 'binary_f1' not in history_dict:
+                history_dict['binary_f1'] = []
+            if 'macro_f1' not in history_dict:
+                history_dict['macro_f1'] = []
+            
+            epochs = len(history_dict['loss'])
+            for _ in range(epochs):
+                history_dict['cmi_score'].append(cmi_score)
+                history_dict['binary_f1'].append(binary_f1)
+                history_dict['macro_f1'].append(macro_f1)
+        
+        if verbose:
+            print(f"CMI評価指標を学習履歴に追加しました:")
+            print(f"  CMI Score: {cmi_score:.4f}")
+            print(f"  Binary F1: {binary_f1:.4f}")
+            print(f"  Macro F1: {macro_f1:.4f}")
+            print(f"  Accuracy: {accuracy:.4f}")
+        
+        return history_dict
+        
+    except Exception as e:
+        print(f"CMI評価指標の追加でエラー: {str(e)}")
+        return history_dict
+
+
+def create_cmi_metrics_history(y_true, y_pred, label_encoder=None, verbose=False):
+    """
+    CMI評価指標のみの学習履歴を作成
+    
+    Parameters:
+    -----------
+    y_true : array-like
+        真のラベル
+    y_pred : array-like
+        予測ラベル
+    label_encoder : LabelEncoder, optional
+        ラベルエンコーダー
+    verbose : bool, default=False
+        詳細ログの出力フラグ
+    
+    Returns:
+    --------
+    dict
+        CMI評価指標の学習履歴辞書
+    """
+    try:
+        # CMI評価指標を計算
+        cmi_score, binary_f1, macro_f1, accuracy = calculate_cmi_score(
+            y_pred, y_true, label_encoder, verbose
+        )
+        
+        # 学習履歴辞書を作成
+        history_dict = {
+            'training_metrics': {
+                'cmi_score': [cmi_score],
+                'binary_f1': [binary_f1],
+                'macro_f1': [macro_f1],
+                'accuracy': [accuracy]
+            },
+            'validation_metrics': {
+                'cmi_score': [cmi_score],
+                'binary_f1': [binary_f1],
+                'macro_f1': [macro_f1],
+                'accuracy': [accuracy]
+            },
+            'metadata': {
+                'timestamp': '2025-01-01 00:00:00',
+                'model_config': {
+                    'num_classes': len(np.unique(y_true)),
+                    'label_encoder_used': label_encoder is not None
+                }
+            },
+            'summary': {
+                'final_cmi_score': cmi_score,
+                'final_binary_f1': binary_f1,
+                'final_macro_f1': macro_f1,
+                'final_accuracy': accuracy
+            }
+        }
+        
+        if verbose:
+            print(f"CMI評価指標の学習履歴を作成しました:")
+            print(f"  CMI Score: {cmi_score:.4f}")
+            print(f"  Binary F1: {binary_f1:.4f}")
+            print(f"  Macro F1: {macro_f1:.4f}")
+            print(f"  Accuracy: {accuracy:.4f}")
+        
+        return history_dict
+        
+    except Exception as e:
+        print(f"CMI評価指標の学習履歴作成でエラー: {str(e)}")
+        return {}
+
+
+if __name__ == "__main__":
+    # モジュールテスト
+    print_gesture_info()
+    
+    print("\n" + "="*60)
+    print("CMI評価指標モジュールの使用方法")
+    print("="*60)
+    
+    print("""
+【基本的な使用方法】
+
+1. CMI評価指標の計算:
+   from utils.cmi_evaluation import calculate_cmi_score
+   
+   cmi_score, binary_f1, macro_f1, accuracy = calculate_cmi_score(
+       y_pred, y_true, label_encoder, verbose=True
+   )
+
+2. ターゲットジェスチャーの取得:
+   from utils.cmi_evaluation import get_target_gestures, get_non_target_gestures
+   
+   target_gestures = get_target_gestures()
+   non_target_gestures = get_non_target_gestures()
+
+3. ジェスチャーの判定:
+   from utils.cmi_evaluation import is_target_gesture
+   
+   is_target = is_target_gesture("Above ear - pull hair")
+
+4. 学習履歴にCMI評価指標を追加:
+   from utils.cmi_evaluation import add_cmi_metrics_to_history
+   
+   updated_history = add_cmi_metrics_to_history(
+       history_dict, y_true, y_pred, label_encoder, verbose=True
+   )
+
+【CMI評価指標の詳細】
+
+- CMI Score: (Binary F1 + Macro F1) / 2.0
+- Binary F1: ターゲット vs 非ターゲットの2値分類F1スコア
+- Macro F1: 全ジェスチャーのマクロF1スコア（非ターゲットは統合）
+
+【ターゲットジェスチャー（8種類）】
+- Above ear - pull hair
+- Cheek - pinch skin
+- Eyebrow - pull hair
+- Eyelash - pull hair
+- Forehead - pull hairline
+- Forehead - scratch
+- Neck - pinch skin
+- Neck - scratch
+
+【非ターゲットジェスチャー（10種類）】
+- Write name on leg
+- Wave hello
+- Glasses on/off
+- Text on phone
+- Write name in air
+- Feel around in tray and pull out an object
+- Scratch knee/leg skin
+- Pull air toward your face
+- Drink from bottle/cup
+- Pinch knee/leg skin
+
+【関連スクリプト】
+
+学習履歴の可視化:
+python src/scripts/visualize_training_history.py --history path/to/training_history.json
+
+CMI評価指標の追加:
+python src/scripts/add_cmi_metrics_to_history.py --demo --output demo_history.json
+""") 

--- a/submissions/v40_64and128/src/utils/config_utils.py
+++ b/submissions/v40_64and128/src/utils/config_utils.py
@@ -1,0 +1,45 @@
+import yaml
+from pathlib import Path
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "config_v2.yaml"
+
+
+def load_config(config_path=None):
+    """Load configuration from specified path or default path.
+    
+    Args:
+        config_path: Path to config file. If None, uses default config.
+        
+    Returns:
+        dict: Configuration dictionary
+    """
+    path = Path(config_path) if config_path else DEFAULT_CONFIG_PATH
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def get_preprocessing_params(config_path=None):
+    """Return preprocessing-related hyperparameters from config.
+    
+    Args:
+        config_path: Path to config file. If None, uses default config.
+        
+    Returns:
+        dict: Preprocessing parameters
+    """
+    cfg = load_config(config_path)
+    return cfg.get("preprocessing", {})
+
+
+def get_cache_dir(cfg: dict | None = None, config_path=None) -> Path:
+    """Return cache directory Path from config.
+    
+    Args:
+        cfg: Configuration dictionary. If None, loads from config_path.
+        config_path: Path to config file. If None, uses default config.
+        
+    Returns:
+        Path: Cache directory path
+    """
+    cfg = cfg or load_config(config_path)
+    return Path(cfg.get("cache_dir", "cache"))

--- a/submissions/v40_64and128/src/utils/feature_engineering.py
+++ b/submissions/v40_64and128/src/utils/feature_engineering.py
@@ -1,0 +1,324 @@
+import numpy as np
+import pandas as pd
+import warnings
+from scipy.signal import find_peaks
+
+# ============================================================
+# A. 基本統計量 (mean / std / range / RMS / energy)
+# ============================================================
+### --- Block A Summary ---------------------------------------
+# dims: 56 | 推奨モデル: LightGBM_all / non
+# 広域量的特徴――窓全体の強度・分布を圧縮
+# ------------------------------------------------------------
+def compute_basic_statistics(X_windows: np.ndarray) -> np.ndarray:
+    """Compute Block F statistics per window."""
+    # 外れ値にロバストな統計量を使用
+    means  = np.nanmean(X_windows, axis=1)
+    stds   = np.nanstd(X_windows, axis=1)
+    
+    # パーセンタイルベースの範囲（外れ値にロバスト）
+    q25 = np.nanpercentile(X_windows, 25, axis=1)
+    q75 = np.nanpercentile(X_windows, 75, axis=1)
+    ranges = q75 - q25  # 四分位範囲（IQR）
+    
+    # 外れ値を除外したRMSとエネルギー
+    # 各ウィンドウで外れ値を除外してから計算
+    rms_values = []
+    energy_values = []
+    
+    for i in range(X_windows.shape[0]):
+        window_data = X_windows[i, :, :]
+        
+        # 外れ値を除外（各軸ごと）
+        clean_data = []
+        for axis in range(window_data.shape[1]):
+            axis_data = window_data[:, axis]
+            q1, q99 = np.nanpercentile(axis_data, [1, 99])
+            clean_axis = axis_data[(axis_data >= q1) & (axis_data <= q99)]
+            clean_data.append(clean_axis)
+        
+        # 全軸のデータを結合
+        all_clean_data = np.concatenate(clean_data)
+        
+        if len(all_clean_data) > 0:
+            rms = np.sqrt(np.nanmean(all_clean_data ** 2))
+            energy = np.nansum(all_clean_data ** 2)
+        else:
+            rms = 0.0
+            energy = 0.0
+            
+        rms_values.append(rms)
+        energy_values.append(energy)
+    
+    rms = np.array(rms_values)
+    energy = np.array(energy_values)
+    
+    if X_windows.shape[2] >= 3:
+        mag = np.linalg.norm(X_windows[:, :, :3], axis=2)
+        mag_mean = np.nanmean(mag, axis=1, keepdims=True)
+        mag_std  = np.nanstd(mag, axis=1, keepdims=True)
+        return np.hstack([means, stds, ranges, rms.reshape(-1, 1), energy.reshape(-1, 1), mag_mean, mag_std])
+    else:
+        return np.hstack([means, stds, ranges, rms.reshape(-1, 1), energy.reshape(-1, 1)])
+
+
+# ============================================================
+# B. ピーク & 周期特徴量
+# ============================================================
+### --- Block B Summary ---------------------------------------
+# dims: 18 | 推奨モデル: LightGBM_all / non
+# BFRB の “反復性” をカウントして数値化
+# ------------------------------------------------------------
+
+def extract_peak_features(window: np.ndarray) -> np.ndarray:
+    """Return per‑axis peak counts (Block D)."""
+    return np.array([len(find_peaks(window[:, i])[0]) for i in range(window.shape[1])], dtype=np.float32)
+
+
+def compute_peak_features(X_windows: np.ndarray) -> np.ndarray:
+    """Compute peak features per window."""
+    def extract_peak_features(window):
+        features = []
+        for axis in range(window.shape[1]):
+            signal = window[:, axis]
+            
+            # 外れ値を除外してからピーク検出
+            q1, q99 = np.nanpercentile(signal, [1, 99])
+            clean_signal = signal[(signal >= q1) & (signal <= q99)]
+            
+            if len(clean_signal) > 10:  # 十分なデータがある場合のみ
+                peaks, _ = find_peaks(clean_signal, height=np.nanmean(clean_signal))
+                n_peaks = len(peaks)
+                
+                if n_peaks > 0:
+                    peak_heights = clean_signal[peaks]
+                    avg_peak_height = np.nanmean(peak_heights)
+                    max_peak_height = np.nanmax(peak_heights)
+                    peak_ratio = n_peaks / len(clean_signal)
+                else:
+                    avg_peak_height = 0.0
+                    max_peak_height = 0.0
+                    peak_ratio = 0.0
+            else:
+                n_peaks = 0
+                avg_peak_height = 0.0
+                max_peak_height = 0.0
+                peak_ratio = 0.0
+            
+            features.extend([n_peaks, avg_peak_height, max_peak_height, peak_ratio])
+        return features
+    
+    return np.vstack([extract_peak_features(w) for w in X_windows])
+
+
+# ============================================================
+# C. FFT バンドエネルギー (0.5–20 Hz)
+# ============================================================
+### --- Block C Summary ---------------------------------------
+# dims: 10 | 推奨モデル: LightGBM_all / non
+# 動作リズム・速度の周波数分布
+# ------------------------------------------------------------
+
+def compute_fft_band_energy(X_windows: np.ndarray, fs: float = 50.0, bands=None) -> np.ndarray:
+    """Compute block G FFT band energies."""
+    if bands is None:
+        bands = [(0.5, 2), (2, 5), (5, 10), (10, 20)]
+    n_win, win_len, n_feat = X_windows.shape
+    freqs = np.fft.rfftfreq(win_len, d=1.0 / fs)
+    
+    energies = []
+    for lo, hi in bands:
+        mask = (freqs >= lo) & (freqs < hi)
+        band_energies = []
+        
+        for i in range(n_win):
+            window_energies = []
+            for j in range(n_feat):
+                signal = X_windows[i, :, j]
+                
+                # 外れ値を除外してからFFT計算
+                q1, q99 = np.nanpercentile(signal, [1, 99])
+                clean_signal = signal[(signal >= q1) & (signal <= q99)]
+                
+                if len(clean_signal) > 10:
+                    # パディングして元の長さに戻す
+                    padded_signal = np.zeros(win_len)
+                    padded_signal[:len(clean_signal)] = clean_signal
+                    
+                    power = np.abs(np.fft.rfft(padded_signal)) ** 2
+                    energy = power[mask].sum()
+                else:
+                    energy = 0.0
+                
+                window_energies.append(energy)
+            band_energies.append(window_energies)
+        
+        energies.append(np.array(band_energies))
+    
+    return np.hstack(energies)
+
+
+# ============================================================
+# E. 欠損フラグ (missing sensor flags)
+# ============================================================
+### --- Block E Summary ---------------------------------------
+# dims: 3 | 推奨モデル: すべて
+# 未接続センサを one-hot で明示
+# ------------------------------------------------------------
+def add_missing_sensor_flags(df: pd.DataFrame, sensor_groups: dict) -> pd.DataFrame:
+    """Add boolean missing‑sensor flags per group (Block E)."""
+    for flag, cols in sensor_groups.items():
+        df[flag] = df[cols].isna().all(axis=1)
+    return df
+
+# ============================================================
+# G. TDA Stats (Persistence Image)
+# ============================================================
+### --- Block G Summary ---------------------------------------
+# dims: 8 | 推奨モデル: CNN-GRU concat / LightGBM
+# 位相的周期性を独自にエンコード
+# ------------------------------------------------------------
+def compute_persistence_image_features(X_windows: np.ndarray, dimension:int=1, n_bins:int=20, sigma:float=0.1) -> np.ndarray:
+    """Block J: persistence image features via giotto‑tda."""
+    from gtda.time_series import TakensEmbedding
+    from gtda.homology import VietorisRipsPersistence
+    from gtda.diagrams import PersistenceImage
+
+    emb = TakensEmbedding(time_delay=1, dimension=dimension)
+    vrp = VietorisRipsPersistence(homology_dimensions=[0, 1])
+    pim = PersistenceImage(sigma=sigma, n_bins=n_bins)
+    feats = []
+    for w in X_windows:
+        e = emb.fit_transform(w)
+        d = vrp.fit_transform(e)
+        img = pim.fit_transform(d)
+        feats.append(img.reshape(-1))
+    return np.array(feats, dtype=np.float32)
+
+def compute_persistence_image_features_batch(
+    X_windows: np.ndarray, dimension: int = 2, n_bins: int = 16, sigma: float = 0.1
+) -> np.ndarray:
+    try:
+        from gtda.time_series import TakensEmbedding
+        from gtda.homology import VietorisRipsPersistence
+        from gtda.diagrams import PersistenceImage
+    except ImportError:
+        warnings.warn(
+            "giotto-tda がインストールされていないため、TDA特徴量をスキップします。"
+        )
+        return np.zeros((X_windows.shape[0], 0), dtype=np.float32)
+
+    # デバッグ: TDA処理前のNaN値確認
+    nan_count = np.isnan(X_windows).sum()
+    if nan_count > 0:
+        print(f"⚠️  TDA処理前: NaN値 {nan_count} 個を発見")
+        print(f"   データ形状: {X_windows.shape}")
+        
+        # NaN値を処理
+        X_windows_clean = np.nan_to_num(X_windows, nan=0.0, posinf=1.0, neginf=-1.0)
+        print(f"✅ NaN値を0.0に置換しました")
+    else:
+        X_windows_clean = X_windows
+        print(f"✅ TDA処理前: NaN値なし")
+
+    # 1. Takens埋め込み（全ウィンドウまとめて）
+    emb = TakensEmbedding(time_delay=1, dimension=dimension)
+    embedded = emb.fit_transform(X_windows_clean)  # shape: (n_samples, new_len, dimension)
+
+    # 2. パーシステンス図（全ウィンドウまとめて）
+    vrp = VietorisRipsPersistence(homology_dimensions=[0, 1])
+    diagrams = vrp.fit_transform(embedded)   # shape: (n_samples, n_points, 3)
+
+    # 3. パーシステンス画像（全ウィンドウまとめて）
+    pim = PersistenceImage(sigma=sigma, n_bins=n_bins)
+    images = pim.fit_transform(diagrams)     # shape: (n_samples, n_bins, n_bins)
+
+    # 4. ベクトル化
+    feats = images.reshape(images.shape[0], -1)
+    return feats.astype(np.float32)
+
+# ============================================================
+# H. Auto-Encoder 再構成誤差
+# ============================================================
+### --- Block H Summary ---------------------------------------
+# dims: 4 | 推奨モデル: LightGBM / Binary-GRU (aux)
+# 異常度スコアで BFRB 境界を補強
+# ------------------------------------------------------------
+
+def compute_autoencoder_reconstruction_error(X_windows: np.ndarray, model) -> np.ndarray:
+    """Block K: per‑window MSE reconstruction error from a trained AE."""
+    recon = model.predict(X_windows, verbose=0)
+    return ((X_windows - recon) ** 2).mean(axis=(1, 2), keepdims=True)
+
+
+
+# ============================================================
+# M. Wavelet 周波数特徴 (DWT energies)
+# ============================================================
+
+def compute_wavelet_features(X_windows: np.ndarray, wavelet: str = "db4", level: int = 3) -> np.ndarray:
+    """Block I: discrete wavelet band energies using PyWavelets."""
+    import pywt
+    
+    # NaN値処理
+    nan_count = np.isnan(X_windows).sum()
+    if nan_count > 0:
+        print(f"⚠️  Wavelet処理前: NaN値 {nan_count} 個を発見")
+        X_windows_clean = np.nan_to_num(X_windows, nan=0.0, posinf=1.0, neginf=-1.0)
+        print(f"✅ NaN値を0.0に置換しました")
+    else:
+        X_windows_clean = X_windows
+    
+    feats = []
+    for w in X_windows_clean:
+        ax_feats = []
+        for i in range(w.shape[1]):
+            coeffs = pywt.wavedec(w[:, i], wavelet=wavelet, level=level)
+            ax_feats += [np.sum(c ** 2) for c in coeffs]
+        feats.append(ax_feats)
+    return np.array(feats, dtype=np.float32)
+
+
+# ============================================================
+# N. ToF イベント特徴量
+# ============================================================
+
+def compute_tof_event_features(X_windows: np.ndarray) -> np.ndarray:
+    """Compute simple ToF event features.
+
+    各ウィンドウについて以下を計算します。
+
+    - 最小距離値
+    - 時系列方向の絶対変化率平均
+    """
+
+    window_min = X_windows.min(axis=(1, 2, 3, 4))[:, None]
+    diff = np.diff(X_windows, axis=1)
+    rate = np.mean(np.abs(diff), axis=(1, 2, 3, 4))[:, None]
+    return np.hstack([window_min, rate])
+
+
+# ============================================================
+# O. 温度勾配特徴量
+# ============================================================
+
+def compute_temperature_gradient_features(X_windows: np.ndarray) -> np.ndarray:
+    """Compute temperature gradient based features.
+
+    Parameters
+    ----------
+    X_windows : np.ndarray
+        Shape ``(N, T, C)`` where ``C`` is the数 of thermal sensors.
+
+    Returns
+    -------
+    np.ndarray
+        ``(N, C*3)`` array containing mean/std of first differences and
+        peak（max-min）for each channel.
+    """
+
+    diffs = np.diff(X_windows, axis=1)
+    diff_mean = diffs.mean(axis=1)
+    diff_std = diffs.std(axis=1)
+    peak_width = X_windows.max(axis=1) - X_windows.min(axis=1)
+    return np.hstack([diff_mean, diff_std, peak_width])

--- a/submissions/v40_64and128/src/utils/imu.py
+++ b/submissions/v40_64and128/src/utils/imu.py
@@ -1,0 +1,47 @@
+# --- utils/imu.py -------------------------------------------------------
+import numpy as np
+import pandas as pd
+from scipy.spatial.transform import Rotation as R
+
+GRAVITY = 9.80665   # [m/s²]
+
+def quat_normalize_safe(quat: np.ndarray) -> np.ndarray:
+    norm = np.linalg.norm(quat, axis=1, keepdims=True)
+    mask_zero = norm.squeeze() < 1e-6
+    quat[mask_zero] = np.array([1, 0, 0, 0])          # identity
+    quat[~mask_zero] /= norm[~mask_zero]
+    return quat
+
+def accel_world_linear(acc: np.ndarray, quat: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Parameters
+    ----------
+    acc  : (N,3) body-frame raw accelerometer
+    quat : (N,4) quaternion (w,x,y,z) body→world
+
+    Returns
+    -------
+    acc_w  : (N,3) world-frame acceleration
+    lin_acc: (N,3) world-frame linear acceleration (= acc_w – g)
+    """
+    quat = quat_normalize_safe(quat)
+    rot  = R.from_quat(quat[:, [1,2,3,0]])            # (x,y,z,w)
+    acc_w = rot.apply(acc)
+    lin   = acc_w - np.array([0, 0, GRAVITY])
+    return acc_w, lin
+
+def add_world_acc_features(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    前提: 欠損補間 & handedness_correction_v2 後の DataFrame
+    追加列:
+        acc_w_[xyz], lin_acc_[xyz]
+    """
+    df = df.copy()
+    acc  = df[['acc_x','acc_y','acc_z']].to_numpy(dtype=np.float32)
+    quat = quat_normalize_safe(                          # ← ここを変更
+        df[['rot_w','rot_x','rot_y','rot_z']].to_numpy(dtype=np.float32)
+    )
+    acc_w, lin = accel_world_linear(acc, quat)
+    df[['acc_w_x','acc_w_y','acc_w_z']]     = acc_w
+    df[['lin_acc_x','lin_acc_y','lin_acc_z']] = lin
+    return df

--- a/submissions/v40_64and128/src/utils/io_utils.py
+++ b/submissions/v40_64and128/src/utils/io_utils.py
@@ -1,0 +1,44 @@
+# src/utils/io_utils.py
+from pathlib import Path
+import pandas as pd, json, hashlib
+
+
+def df_md5(df: pd.DataFrame) -> str:
+    """DataFrame から MD5 ハッシュを計算する"""
+    data = pd.util.hash_pandas_object(df, index=True).values
+    return hashlib.md5(data.tobytes()).hexdigest()
+
+CACHE_DIR   = Path("cache")
+TRAIN_PARQ  = CACHE_DIR / "train_clean.parquet"
+TEST_PARQ   = CACHE_DIR / "test_clean.parquet"
+META_JSON   = CACHE_DIR / "clean_meta.json"
+
+def _md5(path: Path) -> str:
+    return hashlib.md5(path.read_bytes()).hexdigest()
+
+def load_clean_data(raw_train_csv="data/train.csv",
+                    raw_test_csv="data/test.csv",
+                    strict=True):
+    """
+    前処理済み Parquet を読み込む。
+    * strict=True なら MD5 がズレていた場合は例外を投げる
+    """
+    if not TRAIN_PARQ.exists() or not TEST_PARQ.exists():
+        raise FileNotFoundError("cleaned parquet not found – 先に前処理セルを実行してください")
+
+    # MD5 チェック
+    if META_JSON.exists():
+        meta = json.loads(META_JSON.read_text())
+        if strict:
+            if meta["raw_train_md5"] != _md5(Path(raw_train_csv)):
+                raise RuntimeError("raw train CSV has changed – recalc needed")
+            if meta["raw_test_md5"]  != _md5(Path(raw_test_csv)):
+                raise RuntimeError("raw test CSV has changed – recalc needed")
+    else:
+        print("⚠️ meta file not found – skipping MD5 check")
+
+    print("📥 loading cached parquet …", end="", flush=True)
+    train_df = pd.read_parquet(TRAIN_PARQ)
+    test_df  = pd.read_parquet(TEST_PARQ)
+    print("done")
+    return train_df, test_df

--- a/submissions/v40_64and128/src/utils/kaggle.py
+++ b/submissions/v40_64and128/src/utils/kaggle.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+
+def is_kaggle():
+    # Kaggle環境ではこの環境変数が必ず存在
+    return "KAGGLE_URL_BASE" in os.environ or Path("/kaggle").exists()
+
+if is_kaggle():
+    # Kaggle環境
+    PROJECT_ROOT = Path("/kaggle/input/cmi-ensemble-v20/")
+    DATA_DIR = Path("/kaggle/input/cmi-detect-behavior-with-sensor-data/")
+    EVAL_MODULE_DIR = Path("/kaggle/input/cmi-detect-behavior-with-sensor-data/")
+else:
+    # ローカル環境
+    PROJECT_ROOT = Path("/mnt/c/Users/ShunK/works/CMI_comp/submissions/ensemble_v1")
+    DATA_DIR = Path("../../data/")
+    EVAL_MODULE_DIR = Path("/mnt/c/Users/ShunK/works/CMI_comp/submissions/ensemble_v1/kaggle_evaluation")
+
+# # 例：使い方
+# print("PROJECT_ROOT:", PROJECT_ROOT)
+# print("DATA_DIR:", DATA_DIR)
+# print("EVAL_MODULE_DIR:", EVAL_MODULE_DIR)

--- a/submissions/v40_64and128/src/utils/pipeline.py
+++ b/submissions/v40_64and128/src/utils/pipeline.py
@@ -1,0 +1,897 @@
+# -*- coding: utf-8 -*-
+"""Preprocessing pipeline utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import json
+import pickle
+import logging
+from sklearn.preprocessing import StandardScaler
+
+from .io_utils import df_md5
+
+from pathlib import Path
+import yaml
+
+from .preprocessing import (
+    create_sliding_windows_with_demographics,
+    create_tof_windows_with_info,
+    handedness_correction_v2,
+    augment_handedness_flip,
+    clean_sensor_missing_values,
+    clean_missing_sensor_data_parallel_disk,
+)
+from .feature_engineering import add_missing_sensor_flags
+from .config_utils import load_config, get_cache_dir
+from .tof import tof_to_voxel_tensor
+from .feature_engineering import (
+    compute_basic_statistics,
+    compute_peak_features,
+    compute_fft_band_energy,
+    compute_wavelet_features,
+    compute_persistence_image_features_batch,
+    compute_autoencoder_reconstruction_error,
+    compute_tof_event_features,
+    compute_temperature_gradient_features,
+)
+from .imu import add_world_acc_features
+
+
+logger = logging.getLogger(__name__)
+
+class WindowTensorBuilder:
+    """Generate IMU window tensors with demographics."""
+
+    # def __init__(self, config: dict | None = None) -> None:
+    def __init__(self, config: dict | None = None, mode: str = "train") -> None:
+        self.config = config or load_config()
+        self.mode = mode
+        pp = self.config.get("preprocessing", {})
+        self.window_size = pp.get("window_size", 128)
+        self.stride = pp.get("stride", 64)
+        self.min_len = pp.get("min_sequence_length", 10)
+        self.padding_value = pp.get("padding_value", 0.0)
+        
+        self.sensor_cols = (
+            self.config.get("sensor_acc_cols", [])
+            + self.config.get("sensor_rot_cols", [])
+            + self.config.get("sensor_thm_cols", [])
+        )
+        if pp.get("use_world_acc", False):
+            world_acc_cols = [f"acc_w_{ax}" for ax in "xyz"] + [f"lin_acc_{ax}" for ax in "xyz"]
+            self.sensor_cols.extend(world_acc_cols)
+        
+        self.demographics_cols = self.config.get("demographics_cols", [])
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "windows.pkl"
+        self.meta_file = self.cache_dir / "windows_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(self, df: pd.DataFrame, use_cache: bool = True):
+        logger.info(
+            "Building windows (size=%d, stride=%d, min_len=%d)",
+            self.window_size,
+            self.stride,
+            self.min_len,
+        )
+        md5 = df_md5(df)
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached windows from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        result = create_sliding_windows_with_demographics(
+            df,
+            window_size=self.window_size,
+            stride=self.stride,
+            sensor_cols=self.sensor_cols,
+            demographics_cols=self.demographics_cols,
+            min_sequence_length=self.min_len,
+            padding_value=self.padding_value,
+        )
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info(
+            "Windows shapes: X_sensor=%s, X_demo=%s, y=%s",
+            result[0].shape,
+            result[1].shape,
+            result[2].shape,
+        )
+        return result
+
+
+class TabularFeatureBuilder:
+    """Build tabular features from IMU windows."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        self.sampling_rate = pp.get("sampling_rate", 50.0)
+        self.fft_bands = pp.get("fft_bands", [])
+        self.use_wavelet = pp.get("use_wavelet_features", False)
+        self.use_tda = pp.get("use_tda_features", False)
+        self.use_tof_event = pp.get("use_tof_event_features", False)
+        self.use_temp_grad = pp.get("use_temperature_gradient_features", False)
+        self.wavelet = pp.get("wavelet", "db4")
+        self.wavelet_level = pp.get("wavelet_level", 3)
+        self.tda_dimension = pp.get("tda_dimension", 1)
+        self.tda_bins = pp.get("tda_bins", 20)
+        self.tda_sigma = pp.get("tda_sigma", 0.1)
+        self.window_builder = WindowTensorBuilder(self.config)
+        self.tof_win_builder = ToFWindowBuilder(self.config)
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tabular_features.pkl"
+        self.meta_file = self.cache_dir / "tabular_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(
+        self,
+        df: pd.DataFrame,
+        windows=None,
+        use_cache: bool = True,
+        *,
+        use_wavelet: bool | None = None,
+        use_tda: bool | None = None,
+        use_tof_event: bool | None = None,
+        use_temp_grad: bool | None = None,
+        autoencoder_model=None,
+    ):
+        """Return tabular features for each window.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        windows : tuple or None
+            Precomputed window tensors from :class:`WindowTensorBuilder`.
+        use_cache : bool, default True
+            If True, reuse cached results when available.
+        use_wavelet : bool | None, optional
+            Override config to compute wavelet features.
+        use_tda : bool | None, optional
+            Override config to compute TDA features.
+        use_tof_event : bool | None, optional
+            Override config to compute ToF event features.
+        use_temp_grad : bool | None, optional
+            Override config to compute temperature gradient features.
+        autoencoder_model : optional
+            Pre-trained model used to compute reconstruction errors. The
+            object must implement ``predict`` and return reconstructed
+            windows with the same shape as the input.
+        """
+
+        md5 = df_md5(df)
+        use_wavelet = self.use_wavelet if use_wavelet is None else use_wavelet
+        use_tda = self.use_tda if use_tda is None else use_tda
+        use_tof_event = self.use_tof_event if use_tof_event is None else use_tof_event
+        use_temp_grad = self.use_temp_grad if use_temp_grad is None else use_temp_grad
+        logger.info(
+            "Building tabular features (wavelet=%s, tda=%s, tof_event=%s, temp_grad=%s)",
+            use_wavelet,
+            use_tda,
+            use_tof_event,
+            use_temp_grad,
+        )
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached tabular features from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        if windows is None:
+            X_sensor, X_demo, y, info = self.window_builder.build(df, use_cache=use_cache)
+        else:
+            X_sensor, X_demo, y, info = windows
+            
+        # 外れ値処理はPreprocessorで行うため、ここでは不要
+        X_sensor_clean = X_sensor
+        
+        stats = compute_basic_statistics(X_sensor_clean)
+        peaks = compute_peak_features(X_sensor_clean)
+        fft = compute_fft_band_energy(
+            X_sensor_clean, fs=self.sampling_rate, bands=self.fft_bands
+        )
+
+        # decide whether to compute optional features
+        feats = [stats, peaks, fft]
+        if use_wavelet:
+            wave = compute_wavelet_features(
+                X_sensor_clean, wavelet=self.wavelet, level=self.wavelet_level
+            )
+            feats.append(wave)
+        if use_tda:
+            tda = compute_persistence_image_features_batch(
+                X_sensor_clean,
+                dimension=self.tda_dimension,
+                n_bins=self.tda_bins,
+                sigma=self.tda_sigma,
+            )
+            feats.append(tda)
+        if use_tof_event:
+            X_tof, _ = self.tof_win_builder.build(df, use_cache=use_cache)
+            tof_feat = compute_tof_event_features(X_tof)
+            feats.append(tof_feat)
+        if use_temp_grad:
+            thm_cols = self.config.get("sensor_thm_cols", [])
+            if thm_cols:
+                sensor_config = self.window_builder.sensor_cols
+                idx = [sensor_config.index(c) for c in thm_cols if c in sensor_config]
+                if idx:
+                    temp_feat = compute_temperature_gradient_features(
+                        X_sensor_clean[:, :, idx]
+                    )
+                    feats.append(temp_feat)
+        if autoencoder_model is not None:
+            ae_err = compute_autoencoder_reconstruction_error(
+                X_sensor_clean, autoencoder_model
+            ).reshape(len(X_sensor_clean), -1)
+            feats.append(ae_err)
+            
+        # --- 欠損センサフラグ (per-window mean) ----------------------
+        flag_cols = [
+            c
+            for c in [
+                "missing_flag_imu",
+                "missing_flag_thermal",
+                "missing_flag_tof",
+            ]
+            if c in df.columns
+        ]
+        if flag_cols:
+            grouped = {
+                (s, sid): g[flag_cols].to_numpy(float)
+                for (s, sid), g in df.groupby(["subject", "sequence_id"])
+            }
+            flags = []
+            for m in info:
+                arr = grouped[(m["subject"], m["sequence_id"])]
+                start = m["start_idx"]
+                end = min(m["end_idx"], arr.shape[0])
+                flags.append(arr[start:end].mean(axis=0))
+            flag_array = np.vstack(flags)
+            if flag_array.any():
+                feats.append(flag_array)
+
+        # 最終的なNaN値チェック
+        features = np.hstack(feats + [X_demo])
+        final_nan_count = np.isnan(features).sum()
+        if final_nan_count > 0:
+            logger.warning(f"TabularFeatureBuilder: 最終特徴量にNaN値 {final_nan_count} 個を検出、0.0に置換")
+            features = np.nan_to_num(features, nan=0.0, posinf=1.0, neginf=-1.0)
+        result = (features, y, info)
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info("Tabular features shape %s", result[0].shape)
+        return result
+
+
+class ToFVoxelBuilder:
+    """Convert ToF pixel columns to voxel tensor."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        self.fill_value = pp.get("padding_value", 0.0)
+        depth = pp.get("tof_depth", 5)
+        h = pp.get("tof_height", 8)
+        w = pp.get("tof_width", 8)
+        self.tof_cols = [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)]
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tof_voxel.pkl"
+        self.meta_file = self.cache_dir / "tof_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(self, df: pd.DataFrame, use_cache: bool = True):
+        logger.info("Building ToF voxel tensor")
+        md5 = df_md5(df)
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached ToF voxel from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        sub = df[self.tof_cols] if all(c in df.columns for c in self.tof_cols) else df
+        result = tof_to_voxel_tensor(sub, fill_value=self.fill_value)
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info("ToF voxel shape %s", result.shape)
+        return result
+
+
+class ToFWindowBuilder:
+    """Create sliding windows from ToF voxel tensor."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        self.window_size = pp.get("window_size", 128)
+        self.stride = pp.get("stride", 64)
+        self.min_len = pp.get("min_sequence_length", 10)
+        self.fill_value = pp.get("padding_value", 0.0)
+        depth = pp.get("tof_depth", 5)
+        h = pp.get("tof_height", 8)
+        w = pp.get("tof_width", 8)
+        self.tof_cols = [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)]
+        self.cache_dir = get_cache_dir(self.config)
+        self.cache_file = self.cache_dir / "tof_windows.pkl"
+        self.meta_file = self.cache_dir / "tof_windows_meta.json"
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def build(self, df: pd.DataFrame, use_cache: bool = True):
+        logger.info(
+            "Building ToF windows (size=%d, stride=%d, min_len=%d)",
+            self.window_size,
+            self.stride,
+            self.min_len,
+        )
+        md5 = df_md5(df)
+        if use_cache and self.cache_file.exists() and self.meta_file.exists():
+            meta = json.loads(self.meta_file.read_text())
+            if meta.get("md5") == md5:
+                logger.info("Reusing cached ToF windows from %s", self.cache_file)
+                with open(self.cache_file, "rb") as f:
+                    return pickle.load(f)
+
+        result = create_tof_windows_with_info(
+            df,
+            window_size=self.window_size,
+            stride=self.stride,
+            tof_cols=self.tof_cols,
+            min_sequence_length=self.min_len,
+            fill_value=self.fill_value,
+        )
+        if use_cache:
+            with open(self.cache_file, "wb") as f:
+                pickle.dump(result, f)
+            self.meta_file.write_text(json.dumps({"md5": md5}))
+        logger.info("ToF windows shape %s", result[0].shape)
+        return result
+
+
+class Preprocessor:
+    """Manage preprocessing statistics and transformations."""
+
+    def __init__(
+        self,
+        config: dict | None = None,
+        *,
+        use_handedness: bool = True,
+        use_basic_cleaning: bool = True,
+        use_interp_cleaning: bool = True,
+        use_world_acc: bool | None = None,
+    ) -> None:
+        self.config = config or load_config()
+        pp = self.config.get("preprocessing", {})
+        if use_world_acc is None:
+            use_world_acc = pp.get("use_world_acc", False)
+        self.use_handedness_augmentation = pp.get("use_handedness_augmentation", False)
+        self.win_builder = WindowTensorBuilder(self.config)
+        self.tab_builder = TabularFeatureBuilder(self.config)
+        self.tof_builder = ToFVoxelBuilder(self.config)
+        self.tof_win_builder = ToFWindowBuilder(self.config)
+
+        self.sensor_scaler = StandardScaler()
+        self.demo_scaler = StandardScaler()
+        self.tab_scaler = StandardScaler()
+
+        self.use_handedness = use_handedness
+        self.use_basic_cleaning = use_basic_cleaning
+        self.use_interp_cleaning = use_interp_cleaning
+        self.use_world_acc = use_world_acc
+        # handedness augmentation option
+        self.use_handedness_augmentation = bool(self.use_handedness_augmentation)
+
+        pp = self.config.get("preprocessing", {})
+        depth = pp.get("tof_depth", 5)
+        h = pp.get("tof_height", 8)
+        w = pp.get("tof_width", 8)
+        self.sensor_type_groups = {
+            "Accelerometer": list(self.config.get("sensor_acc_cols", [])),
+            "World_Accelerometer": [],  # ワールド座標系専用
+            "Rotation": self.config.get("sensor_rot_cols", []),
+            "Thermal": self.config.get("sensor_thm_cols", []),
+            "ToF_Sensor": [f"tof_{d}_v{i}" for d in range(1, depth + 1) for i in range(h * w)],
+        }
+        if self.use_world_acc:
+            self.sensor_type_groups["World_Accelerometer"].extend(
+                [f"acc_w_{ax}" for ax in "xyz"]
+                + [f"lin_acc_{ax}" for ax in "xyz"]
+            )
+
+        interp_path = Path(__file__).resolve().parents[2] / "config" / "interp_params.yaml"
+        if interp_path.exists():
+            with open(interp_path, "r") as f:
+                self.interp_params = yaml.safe_load(f)
+        else:
+            self.interp_params = None
+
+        self._fitted = False
+
+    def _maybe_clean(self, df: pd.DataFrame) -> pd.DataFrame:
+        processed = df.copy()
+        if self.use_handedness:
+            processed = handedness_correction_v2(processed)
+        if self.use_basic_cleaning:
+            processed = clean_sensor_missing_values(
+                processed, self.sensor_type_groups
+            )
+        # 欠損センサフラグを付与
+        flag_groups = {
+            "missing_flag_imu": self.sensor_type_groups.get("Accelerometer", [])
+            + self.sensor_type_groups.get("Rotation", []),
+            "missing_flag_thermal": self.sensor_type_groups.get("Thermal", []),
+            "missing_flag_tof": self.sensor_type_groups.get("ToF_Sensor", []),
+        }
+        processed = add_missing_sensor_flags(processed, flag_groups)
+
+        if self.use_interp_cleaning:
+            base_keep = self.config.get("demographics_cols", [])
+            # Only include columns that exist in the dataframe
+            keep = [col for col in base_keep + ["gesture"] if col in df.columns]
+            keep.extend(flag_groups.keys())
+            processed = clean_missing_sensor_data_parallel_disk(
+                processed,
+                sensor_type_groups=self.sensor_type_groups,
+                interp_params=self.interp_params,
+                keep_cols=keep,
+            )
+        if self.use_world_acc:
+            processed = add_world_acc_features(processed)
+        return processed
+    
+    def _debug_nan_values(self, X_sensor: np.ndarray, stage: str = ""):
+        """NaN値のデバッグ用関数"""
+        if X_sensor is None:
+            return
+            
+        nan_count = np.isnan(X_sensor).sum()
+        if nan_count > 0:
+            print(f"⚠️  {stage}: NaN値 {nan_count} 個を発見")
+            
+            # どの次元にNaNがあるかを確認
+            nan_mask = np.isnan(X_sensor)
+            if nan_mask.any():
+                # ウィンドウごとのNaN数
+                nan_per_window = nan_mask.sum(axis=(1, 2))
+                windows_with_nan = (nan_per_window > 0).sum()
+                print(f"   NaNを含むウィンドウ数: {windows_with_nan}/{len(X_sensor)}")
+                
+                # 特徴量次元ごとのNaN数
+                nan_per_feature = nan_mask.sum(axis=(0, 1))
+                features_with_nan = (nan_per_feature > 0).sum()
+                print(f"   NaNを含む特徴量数: {features_with_nan}/{X_sensor.shape[-1]}")
+                
+                # 各特徴量のNaN数を詳細表示
+                sensor_config = self.win_builder.sensor_cols
+                print("   各特徴量のNaN数:")
+                for i, count in enumerate(nan_per_feature):
+                    if count > 0:
+                        col_name = sensor_config[i] if i < len(sensor_config) else f"feature_{i}"
+                        print(f"     {col_name} (index {i}): {count} 個")
+                
+                # 最初のNaNの位置を表示
+                nan_indices = np.where(nan_mask)
+                if len(nan_indices[0]) > 0:
+                    first_nan = (nan_indices[0][0], nan_indices[1][0], nan_indices[2][0])
+                    col_name = sensor_config[first_nan[2]] if first_nan[2] < len(sensor_config) else f"feature_{first_nan[2]}"
+                    print(f"   最初のNaN位置: ウィンドウ{first_nan[0]}, 時間{first_nan[1]}, {col_name}(index {first_nan[2]})")
+        else:
+            print(f"✅ {stage}: NaN値なし")
+            
+    def _handle_missing_values_by_sensor_type(self, X_sensor: np.ndarray) -> np.ndarray:
+        """センサー別に適切な欠損値処理を行う"""
+        if X_sensor is None:
+            return X_sensor
+            
+        X_clean = X_sensor.copy()
+        # # デバッグ: 処理前のNaN値確認
+        # self._debug_nan_values(X_sensor, "処理前")
+        
+        # センサー別の処理
+        sensor_config = self.win_builder.sensor_cols
+        acc_cols = self.config.get("sensor_acc_cols", [])
+        rot_cols = self.config.get("sensor_rot_cols", [])
+        thm_cols = self.config.get("sensor_thm_cols", [])
+
+        # ワールド座標系加速度の列を追加
+        world_acc_cols = []
+        if self.use_world_acc:
+            # ワールド座標系加速度の列を追加
+            world_acc_cols = self.sensor_type_groups.get("World_Accelerometer", [])
+            
+        acc_indices = []
+        rot_indices = []
+        thm_indices = []
+        world_acc_indices = []
+        
+        # Accelerometer: 0で置換（物理的に正当）
+        if acc_cols:
+            acc_indices = [sensor_config.index(col) for col in acc_cols if col in sensor_config]
+            for idx in acc_indices:
+                if idx < X_clean.shape[-1]:
+                    X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=0.0)
+        
+        # World Accelerometer: 0で置換（加速度と同様）
+        if world_acc_cols:
+            world_acc_indices = [sensor_config.index(col) for col in world_acc_cols if col in sensor_config]
+            for idx in world_acc_indices:
+                if idx < X_clean.shape[-1]:
+                    X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=0.0)
+    
+        # Rotation: 単位クォータニオンで置換
+        if rot_cols:
+            rot_indices = [sensor_config.index(col) for col in rot_cols if col in sensor_config]
+            for i, idx in enumerate(rot_indices):
+                if idx < X_clean.shape[-1]:
+                    if i == 0:  # w成分
+                        X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=1.0)
+                    else:  # x, y, z成分
+                        X_clean[..., idx] = np.nan_to_num(X_clean[..., idx], nan=0.0)
+        
+        # Thermal: 前後の値で補間（簡易版）
+        if thm_cols:
+            thm_indices = [sensor_config.index(col) for col in thm_cols if col in sensor_config]
+            for idx in thm_indices:
+                if idx < X_clean.shape[-1]:
+                    # 時系列方向で補間
+                    for window_idx in range(X_clean.shape[0]):
+                        series = X_clean[window_idx, :, idx]
+                        if np.isnan(series).any():
+                            # 前後の値で補間（空のスライス対策）
+                            if np.isnan(series).all():
+                                # すべてNaNの場合は0で置換
+                                series_clean = np.zeros_like(series)
+                            else:
+                                # 一部NaNの場合は平均で補間
+                                series_clean = np.nan_to_num(series, nan=np.nanmean(series))
+                            X_clean[window_idx, :, idx] = series_clean
+        
+        # その他のセンサー: 0で置換
+        all_processed_indices = set(acc_indices + rot_indices + thm_indices + world_acc_indices)
+        for i in range(X_clean.shape[-1]):
+            if i not in all_processed_indices:
+                X_clean[..., i] = np.nan_to_num(X_clean[..., i], nan=0.0)
+        
+        # # デバッグ: 処理後のNaN値確認
+        # self._debug_nan_values(X_clean, "処理後")
+        return X_clean
+
+    def _handle_outliers_in_sensor_data(self, X_sensor: np.ndarray, percentile_low: float = 0.5, percentile_high: float = 99.5) -> np.ndarray:
+        """センサーデータの外れ値を処理する
+        
+        Parameters
+        ----------
+        X_sensor : np.ndarray
+            センサーデータ
+        percentile_low : float, default 0.5
+            下位パーセンタイル（より厳しい外れ値検出）
+        percentile_high : float, default 99.5
+            上位パーセンタイル（より厳しい外れ値検出）
+        """
+        if X_sensor is None:
+            return X_sensor
+            
+        X_clean = X_sensor.copy()
+        
+        # 各センサー軸ごとに外れ値を処理
+        for axis in range(X_clean.shape[2]):
+            axis_data = X_clean[:, :, axis]
+            
+            # パーセンタイルベースのクリッピング（ウィンザライゼーション）
+            q_low = np.percentile(axis_data, percentile_low)
+            q_high = np.percentile(axis_data, percentile_high)
+            
+            # 外れ値をクリップ
+            axis_data_clipped = np.clip(axis_data, q_low, q_high)
+            X_clean[:, :, axis] = axis_data_clipped
+            
+            # ログ出力（最初の数軸のみ）
+            if axis < 3:
+                outlier_count = np.sum((axis_data < q_low) | (axis_data > q_high))
+                outlier_ratio = outlier_count / axis_data.size * 100
+                if outlier_ratio > 0.1:  # 0.1%以上の場合のみログ
+                    logger.info(f"軸{axis}: 外れ値{outlier_count:,}個 ({outlier_ratio:.2f}%) をクリップ ({percentile_low}%～{percentile_high}%)")
+        
+        return X_clean
+
+    def fit(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> "Preprocessor":
+        """Fit scalers using the provided dataframe.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        use_cache : bool, default True
+            Reuse cached results when available.
+        autoencoder_model : optional
+            Pre-trained model for reconstruction error features. It must
+            implement ``predict`` and return reconstructed windows.
+
+        Returns
+        -------
+        Preprocessor
+            The fitted instance.
+        """
+        logger.info("Fitting Preprocessor")
+        df_proc = self._maybe_clean(df)
+        if self.use_handedness_augmentation:
+            df_proc = augment_handedness_flip(df_proc)
+        windows = self.win_builder.build(df_proc, use_cache=use_cache)
+        X_sensor, X_demo, y, _ = windows
+        
+        # ラベルエンコーディング
+        if "gesture" in df.columns:
+            from sklearn.preprocessing import LabelEncoder
+            self.label_encoder = LabelEncoder()
+            self.label_encoder.fit(df["gesture"])
+            logger.info(f"ラベルエンコーダー作成: {self.label_encoder.classes_}")
+            logger.info(f"ラベルマッピング: {dict(zip(self.label_encoder.classes_, range(len(self.label_encoder.classes_))))}")
+        
+        # センサー別の適切な欠損値処理と外れ値処理
+        X_sensor_clean = self._handle_missing_values_by_sensor_type(X_sensor)
+        X_sensor_clean = self._handle_outliers_in_sensor_data(X_sensor_clean)
+        logger.info("Window tensor shape %s", X_sensor_clean.shape)
+        self.sensor_scaler.fit(X_sensor_clean.reshape(-1, X_sensor_clean.shape[-1]))
+    
+        
+        # 人口統計データの正規化
+        X_demo_clean = np.nan_to_num(X_demo, nan=0.0)
+        self.demo_scaler.fit(X_demo_clean)
+        
+        # 表形式特徴量の正規化
+        processed_windows = (X_sensor_clean, X_demo, y, windows[3])
+        tab, _, _ = self.tab_builder.build(
+            df_proc,
+            windows=processed_windows,
+            use_cache=use_cache,
+            autoencoder_model=autoencoder_model,
+        )
+        # --- クリップ処理を追加 ---
+        tab_clean = np.nan_to_num(tab, nan=0.0)
+        # クリップ閾値をfit時に保存
+        self.tab_clip_low = np.percentile(tab_clean, 0.5, axis=0)
+        self.tab_clip_high = np.percentile(tab_clean, 99.5, axis=0)
+        tab_clean = np.clip(tab_clean, self.tab_clip_low, self.tab_clip_high)
+        self.tab_scaler.fit(tab_clean)
+        logger.info("Tabular features shape %s", tab.shape)
+        
+        # === ToF正規化パラメータ計算 ===
+        tof_tensor = self.tof_builder.build(df_proc, use_cache=use_cache)
+        # 負の値を欠損値として扱う（-1だけでなく、負の値全体）
+        mask = (tof_tensor > 0)
+        if mask.sum() > 0:
+            self.tof_mean = float(tof_tensor[mask].mean())
+            self.tof_std = float(tof_tensor[mask].std())
+            logger.info(f"ToF mean: {self.tof_mean:.3f}, std: {self.tof_std:.3f} (有効値: {mask.sum():,}個)")
+        else:
+            self.tof_mean = 0.0
+            self.tof_std = 1.0
+            logger.warning("ToF: 有効な正の値が見つかりませんでした")
+
+        # ToF Windowsの正規化パラメータも計算
+        tof_windows_fit, _ = self.tof_win_builder.build(df_proc, use_cache=use_cache)
+        mask_win_fit = (tof_windows_fit > 0)
+        if mask_win_fit.sum() > 0:
+            self.tof_windows_mean = float(tof_windows_fit[mask_win_fit].mean())
+            self.tof_windows_std = float(tof_windows_fit[mask_win_fit].std())
+            logger.info(f"ToF Windows mean: {self.tof_windows_mean:.3f}, std: {self.tof_windows_std:.3f} (有効値: {mask_win_fit.sum():,}個)")
+        else:
+            self.tof_windows_mean = 0.0
+            self.tof_windows_std = 1.0
+            logger.warning("ToF Windows: 有効な正の値が見つかりませんでした")
+
+        self._fitted = True
+        return self
+
+    def transform(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> dict:
+        """Transform dataframe using fitted scalers.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        use_cache : bool, default True
+            Reuse cached results when available.
+        autoencoder_model : optional
+            Pre-trained model used for reconstruction error features. The
+            object must provide ``predict`` returning reconstructed windows.
+
+        Returns
+        -------
+        dict
+            Dictionary containing processed arrays.
+        """
+        if not self._fitted:
+            raise RuntimeError("Preprocessor is not fitted")
+        logger.info("Transforming dataframe of shape %s", df.shape)
+        df_proc = self._maybe_clean(df)
+        if self.use_handedness_augmentation:
+            df_proc = augment_handedness_flip(df_proc)
+        windows = self.win_builder.build(df_proc, use_cache=use_cache)
+        X_sensor, X_demo, y, info = windows
+        
+        # センサー別の適切な欠損値処理、外れ値処理、正規化
+        logger.info("Window tensor shape %s", X_sensor.shape)
+        X_sensor_clean = self._handle_missing_values_by_sensor_type(X_sensor)
+        X_sensor_clean = self._handle_outliers_in_sensor_data(X_sensor_clean)
+        X_sensor_normalized = self.sensor_scaler.transform(
+            X_sensor_clean.reshape(-1, X_sensor_clean.shape[-1])
+        ).reshape(X_sensor_clean.shape)
+        
+        # 人口統計データの正規化
+        X_demo_clean = np.nan_to_num(X_demo, nan=0.0)
+        X_demo_normalized = self.demo_scaler.transform(X_demo_clean)
+        
+        # 表形式特徴量の正規化
+        processed_windows = (X_sensor_clean, X_demo, y, info)
+        tab, _, _ = self.tab_builder.build(
+            df_proc,
+            windows=processed_windows,
+            use_cache=use_cache,
+            autoencoder_model=autoencoder_model,
+        )
+        # 欠損値処理と外れ値処理を追加してfit時とtransform時で一貫性を保つ
+        tab_clean = np.nan_to_num(tab, nan=0.0)
+        # --- クリップ処理をfitで保存した閾値で適用 ---
+        if hasattr(self, "tab_clip_low") and hasattr(self, "tab_clip_high"):
+            tab_clean = np.clip(tab_clean, self.tab_clip_low, self.tab_clip_high)
+        tab_normalized = self.tab_scaler.transform(tab_clean)
+        
+        # === ToF正規化 ===
+        tof_tensor = self.tof_builder.build(df_proc, use_cache=use_cache)
+        # 負の値を欠損値として扱う（-1だけでなく、負の値全体）
+        mask = (tof_tensor > 0)
+        tof_tensor_norm = np.zeros_like(tof_tensor)
+        if hasattr(self, "tof_mean") and hasattr(self, "tof_std") and self.tof_std > 0:
+            tof_tensor_norm[mask] = (tof_tensor[mask] - self.tof_mean) / self.tof_std
+            tof_tensor_norm[~mask] = -1  # 欠損値を-1で埋め戻す
+            logger.info(f"ToF正規化完了: 有効値{mask.sum():,}個, 欠損値{(~mask).sum():,}個")
+        else:
+            tof_tensor_norm = tof_tensor  # 正規化できない場合はそのまま
+            logger.warning("ToF: 正規化パラメータが利用できません")
+            
+        tof_windows, _ = self.tof_win_builder.build(df_proc, use_cache=use_cache)
+        mask_win = (tof_windows > 0)
+        tof_windows_norm = np.zeros_like(tof_windows)
+        if hasattr(self, "tof_windows_mean") and hasattr(self, "tof_windows_std") and self.tof_windows_std > 0:
+            tof_windows_norm[mask_win] = (tof_windows[mask_win] - self.tof_windows_mean) / self.tof_windows_std
+            tof_windows_norm[~mask_win] = -1  # 欠損値を-1で埋め戻す
+            logger.info(f"ToF Windows正規化完了: 有効値{mask_win.sum():,}個, 欠損値{(~mask_win).sum():,}個")
+        else:
+            tof_windows_norm = tof_windows
+            logger.warning("ToF Windows: 正規化パラメータが利用できません")
+            
+        logger.info(
+            "Output shapes: windows=%s, demographics=%s, tabular=%s, tof=%s, tof_win=%s",
+            X_sensor.shape,
+            X_demo.shape,
+            tab.shape,
+            tof_tensor.shape,
+            tof_windows.shape,
+        )
+        # ラベルエンコーディングの適用
+        if hasattr(self, "label_encoder") and y is not None:
+            # testデータかどうかを判定（-1のみの場合はtestデータ）
+            if len(np.unique(y)) == 1 and y[0] == -1:
+                logger.info("testデータのため、ラベルエンコーディングをスキップ")
+                y_encoded = y  # -1のまま保持
+            else:
+                # trainデータの場合のみラベルエンコーディングを適用
+                y_encoded = self.label_encoder.transform(y)
+                logger.info(f"ラベルエンコーディング適用: {np.unique(y_encoded)}")
+        else:
+            y_encoded = y
+        
+        return {
+            "windows": X_sensor_normalized,
+            "demographics": X_demo_normalized,
+            "tabular": tab_normalized,
+            "tof_voxel": tof_tensor_norm,  # 正規化済みデータを使用
+            "tof_windows": tof_windows_norm,  # 正規化済みデータを使用
+            "labels": y_encoded,
+            "info": info,
+        }
+
+    def fit_transform(
+        self,
+        df: pd.DataFrame,
+        use_cache: bool = True,
+        *,
+        autoencoder_model=None,
+    ) -> dict:
+        self.fit(df, use_cache=use_cache, autoencoder_model=autoencoder_model)
+        return self.transform(
+            df, use_cache=use_cache, autoencoder_model=autoencoder_model
+        )
+        """Fit the preprocessor and transform the data in one call.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Raw sensor dataframe.
+        use_cache : bool, default True
+            Reuse cached results when available.
+        autoencoder_model : optional
+            Pre-trained model with ``predict`` returning reconstructed
+            windows.
+
+        Returns
+        -------
+        dict
+            Dictionary of processed arrays.
+        """
+
+        self.fit(df, use_cache=use_cache, autoencoder_model=autoencoder_model)
+        return self.transform(df, use_cache=use_cache, autoencoder_model=autoencoder_model)
+
+    def save(self, path: Path) -> None:
+        """Save scaler objects and settings to a pickle file."""
+        logger.info("Saving Preprocessor to %s", path)
+        data = {
+            "config": self.config,
+            "use_handedness": self.use_handedness,
+            "use_basic_cleaning": self.use_basic_cleaning,
+            "use_interp_cleaning": self.use_interp_cleaning,
+            "use_world_acc": self.use_world_acc,
+            "use_handedness_augmentation": self.use_handedness_augmentation,
+            "sensor_scaler": self.sensor_scaler,
+            "demo_scaler": self.demo_scaler,
+            "tab_scaler": self.tab_scaler,
+            "_fitted": self._fitted,
+            "tof_mean": getattr(self, "tof_mean", None),
+            "tof_std": getattr(self, "tof_std", None),
+            "tof_windows_mean": getattr(self, "tof_windows_mean", None),
+            "tof_windows_std": getattr(self, "tof_windows_std", None),
+            "label_encoder": getattr(self, "label_encoder", None),
+        }
+        with open(path, "wb") as f:
+            pickle.dump(data, f)
+
+    @classmethod
+    def load(cls, path: Path) -> "Preprocessor":
+        """Load scalers and settings from a pickle file."""
+        logger.info("Loading Preprocessor from %s", path)
+        with open(path, "rb") as f:
+            data = pickle.load(f)
+        obj = cls(
+            data.get("config"),
+            use_handedness=data.get("use_handedness", True),
+            use_basic_cleaning=data.get("use_basic_cleaning", True),
+            use_interp_cleaning=data.get("use_interp_cleaning", True),
+            use_world_acc=data.get("use_world_acc"),
+        )
+        obj.sensor_scaler = data["sensor_scaler"]
+        obj.demo_scaler = data["demo_scaler"]
+        obj.tab_scaler = data["tab_scaler"]
+        obj._fitted = data.get("_fitted", False)
+        obj.tof_mean = data.get("tof_mean", None)
+        obj.tof_std = data.get("tof_std", None)
+        obj.tof_windows_mean = data.get("tof_windows_mean", None)
+        obj.tof_windows_std = data.get("tof_windows_std", None)
+        obj.label_encoder = data.get("label_encoder", None)
+        obj.use_handedness_augmentation = data.get("use_handedness_augmentation", False)
+        return obj

--- a/submissions/v40_64and128/src/utils/preprocessing.py
+++ b/submissions/v40_64and128/src/utils/preprocessing.py
@@ -1,0 +1,476 @@
+"""
+Preprocessing utilities for the CMI competition (commented version).
+
+"""
+
+import numpy as np
+import pandas as pd
+from .tof import tof_to_voxel_tensor
+
+
+# ============================================================
+# L. 利き手反転正規化 (Y/Z flip for left‑handed)
+# ============================================================
+from typing import Sequence
+
+def handedness_correction_v2(
+    df: pd.DataFrame,
+    *,
+    imu_prefixes: Sequence[str] = ("acc", "gyro", "rot", "mag"),
+    apply_tof_mirror: bool = True,
+) -> pd.DataFrame:
+    """
+    左利き (handedness==0) サンプルを右利き座標系に正規化する。
+
+    1. IMU (acc/gyro/rot/mag) の Y・Z 軸を符号反転
+       - rot_w は反転しない
+    2. ToF センサは左右ピクセルを鏡像ミラー (値はそのまま)
+       - 値の符号反転は行わない
+    """
+    df = df.copy()
+    left = df["handedness"] == 0
+
+    # --- 1) IMU の Y/Z 反転 ------------------------------------------
+    axis_sign = {"x": 1, "y": -1, "z": -1, "w": 1}       # rot_w は 1
+    for pre in imu_prefixes:
+        axes = ("w", "x", "y", "z") if pre == "rot" else ("x", "y", "z")
+        for ax in axes:
+            col = f"{pre}_{ax}"
+            if col in df.columns:
+                df.loc[left, col] *= axis_sign[ax]
+
+    # --- 2) ToF 水平ミラー -------------------------------------------
+    if apply_tof_mirror:
+        tof_cols = [c for c in df.columns if c.startswith("tof_")]
+        if tof_cols:  # mirror_tof_rows は既存関数を流用
+            df.loc[left, tof_cols] = mirror_tof_rows(df.loc[left, :], tof_cols)
+
+    return df
+
+
+def augment_handedness_flip(
+    df: pd.DataFrame,
+    *,
+    imu_prefixes: Sequence[str] = ("acc", "gyro", "rot", "mag"),
+    apply_tof_mirror: bool = True,
+) -> pd.DataFrame:
+    """左右反転したデータを追加して返すデータ拡張用関数"""
+    df_flip = df.copy()
+
+    # IMU の Y/Z 軸を反転させる
+    for pre in imu_prefixes:
+        axes = ("w", "x", "y", "z") if pre == "rot" else ("x", "y", "z")
+        for ax in axes:
+            col = f"{pre}_{ax}"
+            if col in df_flip.columns and ax in {"y", "z"}:
+                df_flip[col] = -df_flip[col]
+
+    # ToF の左右ピクセルを鏡像ミラー
+    if apply_tof_mirror:
+        tof_cols = [c for c in df_flip.columns if c.startswith("tof_")]
+        if tof_cols:
+            df_flip = mirror_tof_rows(df_flip, tof_cols)
+
+    # 利き手ラベルを反転
+    if "handedness" in df_flip.columns:
+        df_flip["handedness"] = 1 - df_flip["handedness"]
+
+    # 既存の subject/sequence_id と被らないようオフセット
+    if "subject" in df_flip.columns:
+        df_flip["subject"] = df_flip["subject"] + df["subject"].max() + 1
+    if "sequence_id" in df_flip.columns:
+        df_flip["sequence_id"] = df_flip["sequence_id"] + df["sequence_id"].max() + 1
+
+    # 元データと結合
+    return pd.concat([df, df_flip], ignore_index=True)
+
+
+import re
+# ── 1. ToF の水平ミラー（左右反転）関数 ─────────────────────────
+def mirror_tof_rows(df: pd.DataFrame, tof_cols: list[str]) -> pd.DataFrame:
+    """
+    各行の ToF ピクセル(8×8) を水平ミラーします。
+    df[tof_cols] の形状は (N, 64×D) を想定。
+    """
+    pattern = re.compile(r"tof_(\d+)_v(\d+)")
+    # センサIDごとのグループを取得
+    sensor_ids = sorted({int(pattern.match(c).group(1)) for c in tof_cols})
+    out = df.copy()
+    for sid in sensor_ids:
+        # 当該センサの 64 列を時系列順に並べて (N, H, W) にreshape
+        cols = [f"tof_{sid}_v{i}" for i in range(64)]
+        arr = df[cols].to_numpy().reshape(-1, 8, 8)
+        # W方向を反転
+        flipped = arr[:, :, ::-1]
+        # 元に戻して DataFrame に代入
+        out.loc[:, cols] = flipped.reshape(-1, 64)
+    return out
+
+
+# ============================================================
+# Utility : Missing-value Cleaning
+# =============================
+
+# =========================================================
+# D) センサータイプごとに欠損値を適切に処理する関数
+# =========================================================
+
+def clean_sensor_missing_values(
+    df: pd.DataFrame,
+    sensor_type_groups: dict,
+    acc_clip: tuple = (-40.0, 40.0),
+) -> pd.DataFrame:
+    """
+    センサータイプごとに欠損値を適切に処理する関数（調査結果に基づく）
+    
+    ── Rules (調査結果ベース) ────────────────────────────────
+      • Accelerometer :   0 / −1 は正当値 → 極端値 |value|>acc_clip を NaN
+      • Rotation      :   NaN のみ欠損値
+      • ToF_Sensor    :   NaN, -1 および -1 未満 → 欠損値 (NaN 化)
+      • Thermal       :   NaN のみ欠損値
+    ─────────────────────────────────────────────────────────
+    """
+    df = df.copy()
+
+    # ------------------ 1) Accelerometer ------------------
+    acc_cols = sensor_type_groups.get("Accelerometer", [])
+    if acc_cols:
+        # |value| > clip 上限を欠測とみなす
+        df[acc_cols] = df[acc_cols].where(
+            df[acc_cols].abs().le(acc_clip[1]), np.nan
+        )
+
+    # ------------------ 2) ToF_Sensor ---------------------
+    tof_cols = sensor_type_groups.get("ToF_Sensor", [])
+    if tof_cols:
+        # a) 上限超え (255 以上) は NaN
+        df[tof_cols] = df[tof_cols].where(df[tof_cols] <= 254, np.nan)
+        # b) -2 以下も NaN （ハードエラー）
+        df[tof_cols] = df[tof_cols].where(df[tof_cols] >= -1, np.nan)
+        # ※ -1 は “反射なし” → そのまま残す
+
+    # ------------------ 3) Rotation / Thermal -------------
+    # 既定では NaN のみ欠測 → 追加処理不要
+    return df
+
+
+# =========================================================
+# A) 補間パラメータ（調査結果を反映）
+# =========================================================
+# 外部ファイルで定義
+
+# =========================================================
+# B) クォータニオン SLERP と ToF 用補間関数
+# =========================================================
+from scipy.spatial.transform import Rotation, Slerp
+import numpy as np
+import pandas as pd
+
+def _interpolate_quaternion_block(df, cols, time_col, limit):
+    q = df[cols].to_numpy(float)
+
+    # 0-norm → 欠測扱い
+    norm = np.linalg.norm(q, axis=1, keepdims=True)
+    q[norm.squeeze() < 1e-6] = np.nan
+
+    t = df[time_col].to_numpy()
+    mask_nan = np.isnan(q).any(axis=1)
+
+    i = 0
+    while i < len(q):
+        if mask_nan[i]:
+            # --- 欠測 run の [start+1 : end-1] を補間 -----------------
+            start = i - 1               # start は常に定義される
+            j = i
+            while j < len(q) and mask_nan[j]:
+                j += 1
+            end = j                      # first non-NaN idx or len(q)
+            run_len = end - start - 1
+            if start >= 0 and end < len(q) and run_len <= limit:
+                key_times = np.array([t[start], t[end]])
+                key_rots  = Rotation.from_quat(q[[start, end]])
+                slerp = Slerp(key_times, key_rots)
+                q[start+1:end] = slerp(t[start+1:end]).as_quat()
+            i = end                      # ← 欠測 run の次フレームへ
+        else:
+            i += 1                       # 欠測でない→次へ
+
+    # 補間後に正規化
+    valid = ~np.isnan(q).any(axis=1)
+    q[valid] /= np.linalg.norm(q[valid], axis=1, keepdims=True)
+    # まだ NaN があれば identity に
+    q[~valid] = np.array([1,0,0,0])
+
+    return pd.DataFrame(q, columns=cols, index=df.index)
+
+
+
+def _interpolate_tof_block(df, cols, limit, fill_value=-1):
+    """-1 は反射なし → 一時 NaN → 短ラン補間 → -1 に戻す"""
+    blk = df[cols].replace(fill_value, np.nan)
+    blk = blk.interpolate(method="linear",
+                          limit=limit,
+                          limit_direction="both")
+    return blk.fillna(fill_value)
+
+# =========================================================
+# C) 並列 & ディスク結合版クリーニング
+# =========================================================
+from joblib import Parallel, delayed
+from tqdm.auto import tqdm
+import tempfile, shutil
+from pathlib import Path
+
+def clean_missing_sensor_data_parallel_disk(
+    df: pd.DataFrame,
+    sensor_type_groups: dict[str, list[str]],
+    group_cols=("subject", "sequence_id"),
+    time_col: str = "sequence_counter",
+    interp_params: dict | None = None,
+    n_jobs: int = -1,
+    tmp_parent: str | Path = "/tmp/tmp_clean_chunks",
+    keep_tmp: bool = False,
+    keep_cols: list[str] | None = None,        # ★NEW
+) -> pd.DataFrame:
+
+    keep_cols = list(keep_cols or [])
+    base_cols = list(group_cols) + [time_col] + keep_cols
+    
+    # 0) デフォルト
+    default_params = {
+        "Accelerometer": {"method": "linear", "limit": 3},
+        "Rotation":      {"method": "slerp",  "limit": 120},
+        "ToF_Sensor":    {"method": "linear", "limit": 4, "fill_value": -1},
+        "Thermal":       {"method": "linear", "limit": 120},
+    }
+    interp_params = interp_params or default_params
+
+    # 1) ソート
+    df = df.sort_values(list(group_cols) + [time_col]).copy()
+
+    # 2) 一時ディレクトリ
+    tmp_root = Path(tmp_parent); tmp_root.mkdir(exist_ok=True)
+    tmp_dir = tempfile.mkdtemp(dir=tmp_root)
+
+    # 3) 各グループを並列補間 → parquet 保存
+    def _interpolate_and_dump(key, g,
+                            sensor_type_groups, interp_params,
+                            time_col, tmp_dir):
+
+        # --- 欠測補間 -------------------------------------------------
+        for s_type, cols in sensor_type_groups.items():
+            # World_Accelerometerの場合はスキップ
+            if s_type == "World_Accelerometer":
+                continue
+                
+            params = interp_params[s_type]
+            method = params.get("method")
+            limit  = params.get("limit", 3)
+
+            if method is None:
+                continue
+            if s_type == "Rotation":
+                g[cols] = _interpolate_quaternion_block(
+                    g, cols, time_col, limit)
+            elif s_type == "ToF_Sensor":
+                g[cols] = _interpolate_tof_block(
+                    g, cols, limit, params.get("fill_value", -1))
+            else:  # Accelerometer / Thermal
+                g[cols] = g[cols].interpolate(
+                    method=method,
+                    limit=limit,
+                    limit_direction="both"
+                )
+        # -------------------------------------------------------------
+
+        # Parquet 出力
+        subject, seq_id = key
+        # ❶ 保存したい列を計算（存在するカラムのみ）
+        all_cols = base_cols + sum(sensor_type_groups.values(), [])
+        save_cols = list(dict.fromkeys(all_cols))
+        # DataFrameに存在するカラムのみをフィルタ
+        save_cols = [col for col in save_cols if col in g.columns]
+
+
+        # ❷ サブセットを取ってから Parquet 書き出し
+        out_path = Path(tmp_dir) / f"{subject}_{seq_id}.parquet"
+        g.loc[:, save_cols].to_parquet(out_path)   # ← columns 引数を削除
+        return out_path
+
+    # ① (key, grp) を保持
+    groups = [(key, grp) for key, grp in df.groupby(list(group_cols), sort=False)]
+
+    # ② key を _interpolate_and_dump に渡す
+    paths = Parallel(n_jobs=n_jobs, backend="loky")(
+        delayed(_interpolate_and_dump)(
+            key, grp,              # ← 変更
+            sensor_type_groups,
+            interp_params,
+            time_col,
+            tmp_dir
+        )
+        for key, grp in tqdm(groups, desc="interp", unit="seq")
+    )
+    # 4) 結合
+    cleaned = pd.concat(
+        (pd.read_parquet(p) for p in tqdm(paths, desc="concat")),
+        ignore_index=True          # ← sort_index 不要に
+    )
+
+    if not keep_tmp:
+        # 削除はバックグラウンドでも可
+        import threading, shutil
+        threading.Thread(target=shutil.rmtree,
+                        args=(tmp_dir,),
+                        kwargs=dict(ignore_errors=True),
+                        daemon=True).start()
+
+    return cleaned 
+
+# ============================================================
+# I. 合成 Tabular (= A–H)
+# ============================================================
+### --- Block I Summary ---------------------------------------
+# dims: 120 | 推奨モデル: LightGBM_all / CatBoost
+# 木モデル用に Tabular 特徴を統合
+# ------------------------------------------------------------
+# （統合処理は学習パイプライン側で実施）
+
+
+# ============================================================
+# J. IMU Sliding Window Tensor
+# ============================================================
+### --- Block J Summary ---------------------------------------
+# dims: 7×256 = 1 792 | 推奨モデル: Binary-GRU / CNN-GRU
+# 局所パターン＋長期文脈を時系列テンソルで捕捉
+# ------------------------------------------------------------
+def create_sliding_windows_with_demographics(
+    df: pd.DataFrame,
+    window_size: int,
+    stride: int,
+    sensor_cols: list,
+    demographics_cols: list,
+    min_sequence_length: int = 10,
+    padding_value: float = 0.0,
+):
+    """Block B: generate fixed‑length windows and attach static demographics."""
+    X_sensor_windows, X_demographics_windows, y_windows, info = [], [], [], []
+
+    for (subject, seq_id), g in df.groupby(["subject", "sequence_id"]):
+        seq_len = len(g)
+        if seq_len < min_sequence_length:
+            continue
+        sensor = g[sensor_cols].values
+        demo = g[demographics_cols].iloc[0].values
+        
+        # Handle case where gesture column doesn't exist (e.g., test data)
+        if "gesture" in g.columns:
+            gesture = g["gesture"].iloc[0]
+        else:
+            # For test data, we don't have gesture labels
+            # We'll use a placeholder value that won't affect the model training
+            gesture = -1  # Use -1 as placeholder for test data
+        
+        need_pad = seq_len < window_size
+        if need_pad:
+            pad = np.full((window_size - seq_len, len(sensor_cols)), padding_value)
+            sensor = np.vstack([sensor, pad])
+        for s in range(0, len(sensor) - window_size + 1, stride):
+            e = s + window_size
+            X_sensor_windows.append(sensor[s:e])
+            X_demographics_windows.append(demo)
+            y_windows.append(gesture)
+            info.append({"subject": subject, "sequence_id": seq_id, "start_idx": s, "end_idx": e, "padded": need_pad})
+
+    return (
+        np.asarray(X_sensor_windows, dtype=np.float32),
+        np.asarray(X_demographics_windows, dtype=np.float32),
+        np.asarray(y_windows),
+        info,
+    )
+
+
+def create_tof_windows_with_info(
+    df: pd.DataFrame,
+    window_size: int,
+    stride: int,
+    tof_cols: list,
+    min_sequence_length: int = 10,
+    fill_value: float = 0.0,
+) -> tuple[np.ndarray, list[dict]]:
+    """Generate sliding windows for ToF voxel tensor with metadata.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe containing ToF pixel columns.
+    window_size : int
+        Length of each window.
+    stride : int
+        Step size between windows.
+    tof_cols : list
+        Column names of ToF pixels to be used.
+    min_sequence_length : int, default 10
+        Minimum sequence length to consider a sequence.
+    fill_value : float, default 0.0
+        Padding value for sequences shorter than ``window_size``.
+
+    Returns
+    -------
+    tuple[np.ndarray, list[dict]]
+        ``windows`` with shape ``(N, window_size, depth, H, W)`` and
+        ``info`` containing metadata for each window.
+    """
+
+    X_windows, info = [], []
+
+    for (subject, seq_id), g in df.groupby(["subject", "sequence_id"]):
+        seq_len = len(g)
+        if seq_len < min_sequence_length:
+            continue
+
+        tensor = tof_to_voxel_tensor(g[tof_cols], fill_value=fill_value)
+        need_pad = seq_len < window_size
+        if need_pad:
+            pad = np.full(
+                (window_size - seq_len,) + tensor.shape[1:],
+                fill_value,
+                dtype=tensor.dtype,
+            )
+            tensor = np.concatenate([tensor, pad], axis=0)
+
+        for s in range(0, len(tensor) - window_size + 1, stride):
+            e = s + window_size
+            X_windows.append(tensor[s:e])
+            info.append(
+                {
+                    "subject": subject,
+                    "sequence_id": seq_id,
+                    "start_idx": s,
+                    "end_idx": e,
+                    "padded": need_pad,
+                }
+            )
+
+    return np.asarray(X_windows, dtype=np.float32), info
+
+
+
+
+# ============================================================
+# C. 正規化ユーティリティ (sensor / tabular)
+# ============================================================
+
+def normalize_sensor_data(X: np.ndarray):
+    """Block C‑1: z‑score normalisation for sensor windows."""
+    scaler = StandardScaler()
+    n, t, f = X.shape
+    X_flat = np.nan_to_num(X.reshape(-1, f), nan=0.0)
+    X_norm = scaler.fit_transform(X_flat).reshape(n, t, f)
+    return X_norm, scaler
+
+
+def normalize_tabular_data(X: np.ndarray):
+    """Block C‑2: z‑score normalisation for demographics/tabular."""
+    scaler = StandardScaler()
+    return scaler.fit_transform(X), scaler

--- a/submissions/v40_64and128/src/utils/tof.py
+++ b/submissions/v40_64and128/src/utils/tof.py
@@ -1,0 +1,36 @@
+
+"""ToF (Time-of-Flight) related utilities."""
+
+import numpy as np
+import pandas as pd
+
+
+# ============================================================
+# K. ToF 3D Voxel Tensor
+# ============================================================
+### --- Block K Summary ---------------------------------------
+# dims: 20 480 | 推奨モデル: ToF-3D-CNN
+# 顔・対象物との空間的接近パターンを 3D で表現
+# ------------------------------------------------------------
+
+def tof_to_voxel_tensor(df: pd.DataFrame, fill_value: float = -1.0, prefix: str = "tof_") -> np.ndarray:
+    """Block L: convert ToF pixel columns → (T, depth, H, W) tensor."""
+    import re
+    pat = re.compile(fr"^{prefix}(\d+)_v(\d+)$")
+    matches = [(c, pat.match(c)) for c in df.columns]
+    sensors = sorted({int(m.group(1)) for _, m in matches if m})
+    idxs = [int(m.group(2)) for _, m in matches if m]
+    if not sensors:
+        raise ValueError("No ToF columns found")
+    W = H = int(np.sqrt(max(idxs) + 1))
+    T = len(df)
+    D = len(sensors)
+    tensor = np.full((T, D, H, W), fill_value, dtype=np.float32)
+    for d, sn in enumerate(sensors):
+        for idx in range(H * W):
+            col = f"{prefix}{sn}_v{idx}"
+            if col in df.columns:
+                vals = df[col].replace(-1, fill_value).to_numpy(dtype=np.float32)
+                r, c = divmod(idx, W)
+                tensor[:, d, r, c] = vals
+    return tensor


### PR DESCRIPTION
## Summary
- add v40_64, v40_128 and v40_64and128 submission folders
- include prepare scripts for each inference pattern
- provide notebooks describing each variant
- implement dedicated inference pipelines for ws64, ws128 and ws64/ws128 ensemble

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687f323cd744832894d9f1d51b67a7af