### PR TITLE
Add v51 preprocessing and trainer

### DIFF
--- a/config/config_v51.yaml
+++ b/config/config_v51.yaml
@@ -1,0 +1,79 @@
+data_dir: "data"
+cache_dir: "cache"
+output_dir: "output/experiments"
+use_windows: false
+experiment_name: preprocess_v51_anomaly
+
+# preprocessing hyperparameters (no window mode)
+preprocessing:
+  # window関連の設定はno window modeでは不要
+  # window_size: 128
+  # stride: 64
+  min_sequence_length: 20
+  padding_value: -1.0  # ToFデータのパディング値と統一
+  sampling_rate: 50.0
+  # メモリ効率化のための設定
+  n_jobs: 1  # 並列処理を無効化
+  chunk_size: 500  # チャンクサイズ（500に削減）
+  max_sequence_length_limit: 1500  # 最大シーケンス長制限（2000から削減）
+  fft_bands:
+    - [0.5, 2]
+    - [2, 5]
+    - [5, 10]
+    - [10, 20]
+  wavelet: "db4"
+  wavelet_level: 2
+  tda_dimension: 1
+  tda_bins: 8
+  tda_sigma: 0.1
+  # 各特徴量計算の有無を制御
+  use_wavelet_features: true
+  use_tda_features: true
+  use_tof_event_features: false
+  use_temperature_gradient_features: true
+  tof_depth: 5
+  tof_height: 8
+  tof_width: 8
+  use_world_acc: true
+  use_handedness_augmentation: true
+
+
+sensor_acc_cols:
+  - acc_x
+  - acc_y
+  - acc_z
+
+sensor_rot_cols:
+  - rot_w
+  - rot_x
+  - rot_y
+  - rot_z
+
+sensor_thm_cols:
+  - thm_1
+  - thm_2
+  - thm_3
+  - thm_4
+  - thm_5
+
+sensor_tof_cols:
+  - tof_1_v0
+# ToFセンサー（5層×64ピクセル）
+# 例: tof_1_v0〜tof_5_v63
+# 下記はPythonで自動展開することを推奨
+# 例: [f"tof_{d}_v{i}" for d in range(1,6) for i in range(64)]
+
+demographics_cols:
+  - adult_child
+  - age
+  - sex
+  - handedness
+  - height_cm
+  - shoulder_to_wrist_cm
+  - elbow_to_wrist_cm
+# 追加のdemographics項目は現状なし
+# 必要に応じて追記する
+
+training_params:
+  epochs: 50
+  batch_size: 32

--- a/scripts/run_multimodal_training_v51.sh
+++ b/scripts/run_multimodal_training_v51.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# マルチモーダル学習実行スクリプト（v51モデル用）
+# 使用方法: ./scripts/run_multimodal_training_v51.sh
+
+set -e
+
+TRAINER_NAME="multimodal_v51"
+MODEL_NAME="multimodal_model_v51"
+EXPERIMENT_NAME="preprocess_v51_anomaly"
+CONFIG_PATH="./config/config_v51.yaml"
+EPOCHS=50
+BATCH_SIZE=32
+GPU_MEMORY_GROWTH=true
+SAVE_LOGS=true
+
+cd "$(dirname "$0")/.."
+
+if [[ -z "$VIRTUAL_ENV" ]]; then
+    echo "⚠️  仮想環境が有効化されていません"
+    exit 1
+fi
+
+DATA_DIR="output/experiments/$EXPERIMENT_NAME/preprocessed"
+if [[ ! -d "$DATA_DIR" ]]; then
+    echo "❌ データディレクトリが見つかりません: $DATA_DIR"
+    exit 1
+fi
+
+export TF_FORCE_GPU_ALLOW_GROWTH=$GPU_MEMORY_GROWTH
+export CUDA_VISIBLE_DEVICES=0
+export TF_CPP_MIN_LOG_LEVEL=2
+export PYTHONPATH="${PYTHONPATH}:$(pwd)"
+
+LOG_DIR="output/experiments/$EXPERIMENT_NAME/logs"
+mkdir -p "$LOG_DIR"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+LOG_FILE="$LOG_DIR/training_${TIMESTAMP}.log"
+
+PYTHON_SCRIPT="
+import yaml
+from src.trainers.multimodal_trainer_v51 import MultimodalTrainerV51
+with open('$CONFIG_PATH', 'r') as f:
+    config = yaml.safe_load(f)
+train_params = config.get('training_params', {})
+trainer = MultimodalTrainerV51('$EXPERIMENT_NAME')
+data = trainer.load_all_data()
+history = trainer.train_cross_validation(
+    data,
+    epochs=train_params.get('epochs', $EPOCHS),
+    batch_size=train_params.get('batch_size', $BATCH_SIZE)
+)
+trainer.save_model()
+results = trainer.evaluate(data)
+trainer.save_training_history()
+trainer.save_evaluation_results(results)
+print('Macro F1 Score:', results.get('macro_f1', None))
+print('CMI Score:', results.get('cmi_score', None))
+print('学習完了！')
+"
+
+if [[ "$SAVE_LOGS" == "true" ]]; then
+    echo "📝 ログファイル: $LOG_FILE"
+    python -c "$PYTHON_SCRIPT" 2>&1 | tee "$LOG_FILE"
+else
+    python -c "$PYTHON_SCRIPT"
+fi
+
+echo "✅ マルチモーダル学習完了 (v51モデル)"

--- a/scripts/run_preprocessing_no_windows.py
+++ b/scripts/run_preprocessing_no_windows.py
@@ -598,19 +598,18 @@ class NoWindowPreprocessor(Preprocessor):
         else:
             y_encoded = labels
         
+        features = np.hstack([X_demo_normalized, tab_normalized])
         logger.info(
-            "Output shapes: sequences=%d, demographics=%s, tabular=%s, tof_chunks=%d",
+            "Output shapes: sequences=%d, features=%s, tof_chunks=%d",
             len(X_sensor_normalized),
-            X_demo_normalized.shape,
-            tab_normalized.shape,
+            features.shape,
             len(normalized_chunk_files),
         )
-        
+
         return {
-            "sequences": X_sensor_normalized,  # シーケンス単位のセンサーデータ
-            "demographics": X_demo_normalized,
-            "tabular": tab_normalized,
-            "tof_voxels": tof_chunk_info,  # チャンクファイル情報
+            "sequences": X_sensor_normalized,
+            "features": features,
+            "tof_voxels": tof_chunk_info,
             "labels": y_encoded,
             "info": sequence_info,
         }
@@ -619,10 +618,8 @@ class NoWindowPreprocessor(Preprocessor):
 def generate_feature_names_no_windows(config: dict) -> dict[str, list[str]]:
     """Generate feature names for sequence-level processing."""
     feature_names = {}
-    
-    # Demographics feature names
+
     demographics_cols = config.get("demographics_cols", [])
-    feature_names["demographics"] = demographics_cols
     
     # Sensor feature names
     sensor_cols = (
@@ -655,8 +652,8 @@ def generate_feature_names_no_windows(config: dict) -> dict[str, list[str]]:
         for col in sensor_cols:
             tabular_features.append(f"{col}_fft_{low}_{high}Hz")
     
-    feature_names["tabular"] = tabular_features
-    
+    feature_names["features"] = demographics_cols + tabular_features
+
     # ToF feature names (simplified)
     tof_features = []
     pp_config = config.get("preprocessing", {})
@@ -709,7 +706,11 @@ def save_dict_no_windows(data: dict, prefix: str, out_dir: Path, config: dict) -
     logger.info(f"Saving {len(data)} data files...")
     
     # Save data files
-    for i, (key, value) in enumerate(data.items()):
+    order = ["sequences", "features", "tof_voxels", "labels", "info"]
+    for i, key in enumerate(order):
+        value = data.get(key)
+        if value is None:
+            continue
         if key == "tof_voxels" and isinstance(value, dict):
             # ToFチャンクファイルの特別処理
             logger.info(f"Saving {key} (chunk files)...")
@@ -750,7 +751,7 @@ def save_dict_no_windows(data: dict, prefix: str, out_dir: Path, config: dict) -
         else:
             # 通常のデータファイル保存
             file = out_dir / f"{prefix}_{key}.pkl"
-            logger.info(f"Saving {key} ({i+1}/{len(data)})...")
+            logger.info(f"Saving {key} ({i+1}/{len(order)})...")
             with open(file, "wb") as f:
                 pickle.dump(value, f)
             logger.info("Saved %s", file)

--- a/scripts/run_preprocessing_no_windows.sh
+++ b/scripts/run_preprocessing_no_windows.sh
@@ -14,7 +14,7 @@ echo "実験名: $EXPERIMENT_NAME"
 # 前処理実行
 python scripts/run_preprocessing_no_windows.py \
     --experiment-name $EXPERIMENT_NAME \
-    --config config/config_v50.yaml \
+    --config config/config_v51.yaml \
     --mode train
 
 echo "=== 前処理完了 ==="

--- a/src/trainers/multimodal_trainer_v51.py
+++ b/src/trainers/multimodal_trainer_v51.py
@@ -32,16 +32,16 @@ import tensorflow as tf
 from tensorflow import keras
 
 
-class MultimodalTrainerV50:
-    """Minimal trainer that builds a model with mask input."""
+class MultimodalTrainerV51:
+    """Trainer for v51 sequence-level data."""
 
 
     def __init__(self, experiment_name: str = "multimodal") -> None:
         self.experiment_name = experiment_name
         self.base_dir = Path("output/experiments") / experiment_name
         self.data_dir = self.base_dir / "preprocessed"
-        self.model_dir = self.base_dir / "models"
-        self.result_dir = self.base_dir / "results"
+        self.model_dir = self.base_dir / "models_v51"
+        self.result_dir = self.base_dir / "results_v51"
 
         self.model_dir.mkdir(parents=True, exist_ok=True)
         self.result_dir.mkdir(parents=True, exist_ok=True)
@@ -98,14 +98,13 @@ class MultimodalTrainerV50:
                     return pickle.load(f)
             raise FileNotFoundError(f"{name} ファイルが見つかりません")
 
-        X_sensor = _load("train_windows")
-        sensor_mask = self._create_mask(X_sensor)
-        X_demo = _load("train_demographics")
-        X_tab = _load("train_tabular")
-        X_tab = X_tab.astype(np.float32)
-        X_tof = _load("train_tof_windows")
-        y = _load("train_labels")
+        X_sensor = _load("train_sequences")
         info = _load("train_info")
+        sensor_mask = self._create_mask(X_sensor, padding_value=-1)
+        X_feat = _load("train_features")
+        X_feat = X_feat.astype(np.float32)
+        X_tof = _load("train_tof_voxels")
+        y = _load("train_labels")
 
         if isinstance(info, list) and len(info) > 0 and isinstance(info[0], dict):
             groups = np.array([
@@ -115,16 +114,14 @@ class MultimodalTrainerV50:
             groups = np.asarray(info)
 
         print(f"センサー: {X_sensor.shape}")
-        print(f"人口統計: {X_demo.shape}")
-        print(f"表形式: {X_tab.shape}")
+        print(f"特徴量: {X_feat.shape}")
         print(f"ToF: {X_tof.shape}")
         print(f"ラベル: {y.shape}")
         print(f"グループ数: {len(groups)}")
 
         return {
             "sensor": X_sensor,
-            "demographics": X_demo,
-            "tabular": X_tab,
+            "features": X_feat,
             "tof": X_tof,
             "labels": y,
             "groups": groups,
@@ -134,8 +131,7 @@ class MultimodalTrainerV50:
     def build_multimodal_model(
         self,
         sensor_shape: tuple,
-        demo_shape: int,
-        tab_shape: int,
+        feat_shape: int,
         tof_shape: tuple,
         num_classes: int,
         *,
@@ -148,39 +144,33 @@ class MultimodalTrainerV50:
         x1 = keras.layers.Masking()(sensor_input)
         x1 = keras.layers.Bidirectional(keras.layers.LSTM(32))(x1, mask=sensor_mask_input)
 
-        # 2. Demographics Tower
-        demo_input = keras.Input(shape=(demo_shape,), name="demo")
-        x2 = keras.layers.Dense(32, activation="relu")(demo_input)
-
-        # 3. Tabular Tower (Residual Connection)
-        tab_input = keras.Input(shape=(tab_shape,), name="tabular")
-        x3_base = keras.layers.Dense(64, activation="relu")(tab_input)
-        x3_res = keras.layers.Dense(64, activation="relu")(x3_base)
-        x3 = keras.layers.Add()([x3_base, x3_res])
+        # 2. Integrated feature tower
+        feat_input = keras.Input(shape=(feat_shape,), name="features")
+        x2 = keras.layers.Dense(128, activation="relu")(feat_input)
 
         # 4. ToF Tower (3D ResNet)
         tof_input = keras.Input(shape=tof_shape, name="tof")
-        x4 = self._resnet_block_3d(tof_input, filters=16, stride=2)
+        x_toF = keras.layers.Lambda(lambda t: tf.where(t == -1, 0.0, t))(tof_input)
+        x4 = self._resnet_block_3d(x_toF, filters=16, stride=2)
         x4 = self._resnet_block_3d(x4, filters=32, stride=2)
         if use_attention:
             x4 = keras.layers.SpatialDropout3D(0.2)(x4)
         x4 = keras.layers.GlobalAveragePooling3D()(x4)
 
         if use_attention:
-            # IMU と ToF 特徴量間でアテンションを計算
             q = keras.layers.Reshape((1, 64))(keras.layers.Dense(64)(x1))
             v = keras.layers.Reshape((1, 64))(keras.layers.Dense(64)(x4))
             attn = keras.layers.MultiHeadAttention(num_heads=4, key_dim=64)(q, v)
             attn = keras.layers.Flatten()(attn)
-            merged = keras.layers.concatenate([attn, x2, x3])
+            merged = keras.layers.concatenate([attn, x2])
         else:
-            merged = keras.layers.concatenate([x1, x2, x3, x4])
+            merged = keras.layers.concatenate([x1, x2, x4])
         merged = keras.layers.Dense(64, activation="relu")(merged)
         merged = keras.layers.Dropout(0.3)(merged)
         output = keras.layers.Dense(num_classes, activation="softmax")(merged)
 
         model = keras.Model(
-            inputs=[sensor_input, sensor_mask_input, demo_input, tab_input, tof_input],
+            inputs=[sensor_input, sensor_mask_input, feat_input, tof_input],
             outputs=output,
         )
 
@@ -203,9 +193,8 @@ class MultimodalTrainerV50:
     def _train_fold(
         self,
         X_s: np.ndarray,
-        X_d: np.ndarray,
-        X_t: np.ndarray,
-        X_f: np.ndarray,
+        X_feat: np.ndarray,
+        X_tof: np.ndarray,
         m_s: np.ndarray,
         y: np.ndarray,
         train_idx: np.ndarray,
@@ -218,9 +207,8 @@ class MultimodalTrainerV50:
         """単一foldでモデルを学習しF1スコアを返す"""
         model = self.build_multimodal_model(
             sensor_shape=(None, X_s.shape[2]),
-            demo_shape=X_d.shape[1],
-            tab_shape=X_t.shape[1],
-            tof_shape=X_f.shape[1:],
+            feat_shape=X_feat.shape[1],
+            tof_shape=X_tof.shape[1:],
             num_classes=len(np.unique(y)),
             use_attention=use_attention,
         )
@@ -228,10 +216,10 @@ class MultimodalTrainerV50:
         weights = compute_class_weight(class_weight="balanced", classes=classes, y=y[train_idx])
         class_weight = {cls: w for cls, w in zip(classes, weights)}
         history = model.fit(
-            [X_s[train_idx], m_s[train_idx], X_d[train_idx], X_t[train_idx], X_f[train_idx]],
+            [X_s[train_idx], m_s[train_idx], X_feat[train_idx], X_tof[train_idx]],
             y[train_idx],
             validation_data=(
-                [X_s[val_idx], m_s[val_idx], X_d[val_idx], X_t[val_idx], X_f[val_idx]],
+                [X_s[val_idx], m_s[val_idx], X_feat[val_idx], X_tof[val_idx]],
                 y[val_idx],
             ),
             epochs=epochs,
@@ -240,7 +228,7 @@ class MultimodalTrainerV50:
             callbacks=[keras.callbacks.EarlyStopping(patience=10, restore_best_weights=True)],
             verbose=1,
         )
-        preds = model.predict([X_s[val_idx], m_s[val_idx], X_d[val_idx], X_t[val_idx], X_f[val_idx]])
+        preds = model.predict([X_s[val_idx], m_s[val_idx], X_feat[val_idx], X_tof[val_idx]])
         pred_labels = preds.argmax(axis=1)
         f1 = f1_score(y[val_idx], pred_labels, average="macro")
         
@@ -259,8 +247,7 @@ class MultimodalTrainerV50:
     ) -> keras.callbacks.History:
         print("=== データ型確認 ===")
         print(f"X_sensor dtype: {data['sensor'].dtype}")
-        print(f"X_demo dtype: {data['demographics'].dtype}")
-        print(f"X_tabular dtype: {data['tabular'].dtype}")
+        print(f"X_features dtype: {data['features'].dtype}")
         print(f"X_tof dtype: {data['tof'].dtype}")
         print(f"y dtype: {data['labels'].dtype}")
         print(f"y unique values: {np.unique(data['labels'])}")        
@@ -269,9 +256,8 @@ class MultimodalTrainerV50:
         m_s = data.get("sensor_mask")
         if m_s is None:
             m_s = self._create_mask(X_s)
-        X_d = data["demographics"]
-        X_t = data["tabular"]
-        X_f = data["tof"]
+        X_feat = data["features"]
+        X_tof = data["tof"]
         y = data["labels"]
 
         Xs_train, Xs_val, yd_train, yd_val = train_test_split(
@@ -279,9 +265,8 @@ class MultimodalTrainerV50:
         )
         model, history, _, _ = self._train_fold(
             X_s,
-            X_d,
-            X_t,
-            X_f,
+            X_feat,
+            X_tof,
             m_s,
             y,
             Xs_train,
@@ -307,8 +292,7 @@ class MultimodalTrainerV50:
         """StratifiedGroupKFold を用いたクロスバリデーション学習"""
         print("=== データ型確認 ===")
         print(f"X_sensor dtype: {data['sensor'].dtype}")
-        print(f"X_demo dtype: {data['demographics'].dtype}")
-        print(f"X_tabular dtype: {data['tabular'].dtype}")
+        print(f"X_features dtype: {data['features'].dtype}")
         print(f"X_tof dtype: {data['tof'].dtype}")
         print(f"y dtype: {data['labels'].dtype}")
         print(f"y unique values: {np.unique(data['labels'])}")
@@ -317,9 +301,8 @@ class MultimodalTrainerV50:
         m_s = data.get("sensor_mask")
         if m_s is None:
             m_s = self._create_mask(X_s)
-        X_d = data["demographics"]
-        X_t = data["tabular"]
-        X_f = data["tof"]
+        X_feat = data["features"]
+        X_tof = data["tof"]
         y = data["labels"]
 
         if groups is None:
@@ -334,9 +317,8 @@ class MultimodalTrainerV50:
             print(f"Fold {fold}/{n_splits}")
             model, history, f1, cmi_score = self._train_fold(
                 X_s,
-                X_d,
-                X_t,
-                X_f,
+                X_feat,
+                X_tof,
                 m_s,
                 y,
                 tr_idx,
@@ -350,7 +332,7 @@ class MultimodalTrainerV50:
             fold_histories.append(history)
             
             # モデル保存
-            model_path = self.model_dir / f"multimodal_model_v50_fold{fold}.keras"
+            model_path = self.model_dir / f"multimodal_model_v51_fold{fold}.keras"
             model.save(model_path)
             print(f"モデル保存: {model_path}")
             
@@ -399,12 +381,11 @@ class MultimodalTrainerV50:
         m_s = data.get("sensor_mask")
         if m_s is None:
             m_s = self._create_mask(X_s)
-        X_d = data["demographics"]
-        X_t = data["tabular"]
-        X_f = data["tof"]
+        X_feat = data["features"]
+        X_tof = data["tof"]
         y = data["labels"]
 
-        preds = self.model.predict([X_s, m_s, X_d, X_t, X_f])
+        preds = self.model.predict([X_s, m_s, X_feat, X_tof])
         pred_labels = preds.argmax(axis=1)
 
         label_encoder = None


### PR DESCRIPTION
## Summary
- introduce `config_v51.yaml` with experiment name
- update preprocessing shell for v51
- add trainer and training shell for v51
- adjust preprocessing script to output combined features
- fix colon typo in `multimodal_trainer_v50`

## Testing
- `pytest -q` *(fails: AttributeError, KeyError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6889dbc911d48328bf50ca7606137ddc